### PR TITLE
Update ImgLib2 to v7

### DIFF
--- a/scijava-ops-image/pom.xml
+++ b/scijava-ops-image/pom.xml
@@ -266,6 +266,11 @@
 		<scijava-maven-plugin.version>3.0.0</scijava-maven-plugin.version>
 		<imglib2-mesh.version>1.0.0</imglib2-mesh.version>
 		<net.imglib2.imglib2-mesh.version>${imglib2-mesh.version}</net.imglib2.imglib2-mesh.version>
+
+		<imglib2.version>7.0.1</imglib2.version>
+		<imglib2-roi.version>0.15.0</imglib2-roi.version>
+		<imglib2-algorithm.version>0.15.1</imglib2-algorithm.version>
+		<imglib2-realtransform.version>4.0.3</imglib2-realtransform.version>
 	</properties>
 
 	<dependencies>

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/coloc/ShuffledView.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/coloc/ShuffledView.java
@@ -126,6 +126,11 @@ public class ShuffledView<T> extends AbstractInterval implements
 	}
 
 	@Override
+	public T getType() {
+		return image.getType();
+	}
+
+	@Override
 	public RandomAccess<T> randomAccess() {
 		return new ShuffledRandomAccess();
 	}

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/geom/geom3d/DefaultInertiaTensor3D.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/geom/geom3d/DefaultInertiaTensor3D.java
@@ -68,7 +68,7 @@ public class DefaultInertiaTensor3D<B extends BooleanType<B>> implements
 			"Only three-dimensional inputs allowed!");
 
 		final var output = new BlockRealMatrix(3, 3);
-        var c = input.localizingCursor();
+        var c = input.inside().localizingCursor();
         var pos = new double[3];
         var computedCentroid = new double[3];
 		centroid.apply(input).localize(computedCentroid);
@@ -95,7 +95,7 @@ public class DefaultInertiaTensor3D<B extends BooleanType<B>> implements
 			output.setEntry(2, 1, output.getEntry(1, 2));
 		}
 
-		final double size = input.size();
+		final double size = input.inside().size();
 		output.setEntry(0, 0, output.getEntry(0, 0) / size);
 		output.setEntry(0, 1, output.getEntry(0, 1) / size);
 		output.setEntry(0, 2, output.getEntry(0, 2) / size);

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/image/watershed/Watershed.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/image/watershed/Watershed.java
@@ -138,7 +138,7 @@ public class Watershed<T extends RealType<T>, B extends BooleanType<B>>
 		final List<Long> imiList = new ArrayList<>();
 
 		if (mask != null) {
-			final var c = Regions.iterable(mask).localizingCursor();
+			final var c = Regions.iterable(mask).inside().localizingCursor();
 			while (c.hasNext()) {
 				c.next();
 				imiList.add(IntervalIndexer.positionToIndex(c, in));

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/image/watershed/WatershedSeeded.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/image/watershed/WatershedSeeded.java
@@ -206,8 +206,7 @@ public class WatershedSeeded<T extends RealType<T>, B extends BooleanType<B>>
 
 		// Only iterate seeds that are not excluded by the mask
 		final var maskRegions = Regions.iterable(mask);
-		final var seedsMasked = Regions.sample(
-			(IterableInterval<Void>) maskRegions, seeds);
+		final var seedsMasked = Regions.sample(maskRegions.inside(), seeds);
 		final var cursorSeeds = seedsMasked
 			.localizingCursor();
 

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/imagemoments/AbstractImageMomentOp.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/imagemoments/AbstractImageMomentOp.java
@@ -46,7 +46,7 @@ public interface AbstractImageMomentOp<I extends RealType<I>, O extends RealType
 	extends Computers.Arity1<RandomAccessibleInterval<I>, O>
 {
 
-	public void computeMoment(RandomAccessibleInterval<I> input, O output);
+	void computeMoment(RandomAccessibleInterval<I> input, O output);
 
 	/**
 	 * TODO

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/labeling/MergeLabeling.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/labeling/MergeLabeling.java
@@ -32,10 +32,7 @@ package org.scijava.ops.image.labeling;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import net.imglib2.Cursor;
 import net.imglib2.Dimensions;
-import net.imglib2.IterableInterval;
-import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.roi.Regions;
@@ -43,7 +40,6 @@ import net.imglib2.roi.labeling.ImgLabeling;
 import net.imglib2.roi.labeling.LabelingType;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.IntegerType;
-import net.imglib2.view.Views;
 
 import org.scijava.function.Computers;
 import org.scijava.function.Functions;
@@ -72,24 +68,21 @@ public class MergeLabeling<L, I extends IntegerType<I>, B extends BooleanType<B>
 	 * TODO
 	 *
 	 * @param input1
-	 * @param input1
+	 * @param input2
 	 * @param mask
 	 * @return an {@link ImgLabeling} that combines the labels of {@code input1}
 	 *         and {@code input2}
 	 */
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes", "hiding" })
 	public ImgLabeling<L, I> apply( //
 		final ImgLabeling<L, I> input1, //
 		final ImgLabeling<L, I> input2, //
 		@Nullable final RandomAccessibleInterval<B> mask //
 	) {
-		final var output = imgLabelingCreator.apply(input1, Views
-			.iterable(input1.getSource()).firstElement());
+		final var output = imgLabelingCreator.apply(input1, input1.getSource().firstElement());
 		if (mask != null) {
-			final IterableRegion iterable = Regions.iterable(mask);
-			final var sample = Regions.sample(
-				(IterableInterval<Void>) iterable, output);
+			final IterableRegion<B> iterable = Regions.iterable(mask);
+			final var sample = Regions.sample(iterable.inside(), output);
 			final var randomAccess = input1.randomAccess();
 			final var randomAccess2 = input2.randomAccess();
 			final var cursor = sample.cursor();

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/image/watershed/WatershedSeededTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/image/watershed/WatershedSeededTest.java
@@ -219,7 +219,7 @@ public class WatershedSeededTest extends AbstractOpTest {
 		// count labels
 		Set<Integer> labelSet = new HashSet<>();
 		for (LabelingType<Integer> pixel : Regions.sample(
-			(IterableInterval<Void>) regions, out))
+			regions.inside(), out))
 		{
 			labelSet.addAll(pixel);
 		}

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/image/watershed/WatershedTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/image/watershed/WatershedTest.java
@@ -220,7 +220,7 @@ public class WatershedTest extends AbstractOpTest {
 		// count labels
 		Set<Integer> labelSet = new HashSet<>();
 		for (LabelingType<Integer> pixel : Regions.sample(
-			(IterableInterval<Void>) regions, out))
+			regions.inside(), out))
 		{
 			labelSet.addAll(pixel);
 		}


### PR DESCRIPTION
This PR updates the version of ImgLib2 used in scijava-ops-image to the latest 7.0.1 release, which includes backwards-incompatible changes resulting from the inclusion of the new getType() method.

It also performs various cleanups to the POMs.

On my system, tests are failing. But they also fail on the main branch. So we'll see how the CI likes it.
