### PR TITLE
Ensure taglets and indexer built first

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,8 +1,3 @@
 #!/bin/sh
 curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/main/ci-build.sh
-
-# NB: These two components must be pre-built before the project as a whole,
-# because they are used as helpers during the project build itself.
-mvn -Djavadoc.skip -pl scijava-taglets,scijava-ops-indexer -am clean install
-
 sh ci-build.sh

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 	<version>0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<name>SciJava Incubator</name>
-	<description>A wonderful bag of cats.</description>
+	<name>SciJava Parent</name>
+	<description>The parent module of the core SciJava suite.</description>
 	<url>https://github.com/scijava/scijava</url>
 	<inceptionYear>2020</inceptionYear>
 	<organization>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
 	</mailingLists>
 
 	<modules>
+		<!--Some modules are implicit dependencies of later modules; they should build first-->
+		<module>scijava-ops-indexer</module>
+		<module>scijava-taglets</module>
+		<!-- End implicit dependencies -->
 		<module>scijava-collections</module>
 		<module>scijava-common3</module>
 		<module>scijava-concurrent</module>
@@ -57,7 +61,6 @@
 		<module>scijava-ops-flim</module>
 		<module>scijava-ops-image</module>
 		<module>scijava-ops-legacy</module>
-		<module>scijava-ops-indexer</module>
 		<module>scijava-ops-opencv</module>
 		<module>scijava-ops-ext-parser</module>
 		<module>scijava-ops-spi</module>
@@ -65,7 +68,6 @@
 		<module>scijava-priority</module>
 		<module>scijava-progress</module>
 		<module>scijava-struct</module>
-		<module>scijava-taglets</module>
 		<module>scijava-testutil</module>
 		<module>scijava-types</module>
 	</modules>


### PR DESCRIPTION
This PR fixes errors where the implicit dependent libraries, like the SciJava Ops Indexer or SciJava Taglets, have not been built, or are old, and are not built before modules needing them in the build. In other words, the following two scenarios now work:

1) Building e.g. the SciJava Ops Engine when the SciJava Ops Indexer has not yet been built locally (either due to a removal of the `~/.m2` folder or otherwise)
2) Building e.g. the SciJava Ops Engine when the SciJava Ops Indexer has just been modified.

What does not work with this change is running e.g. `mvn clean install -pl scijava-ops-engine -am` when either (1) or (2), hold, as this change does *not* make the SciJava Ops Engine explicitly dependent upon the Indexer.