### PR TITLE
Adaptation: Ignore Any assignments

### DIFF
--- a/scijava-common3/src/main/java/org/scijava/common3/Any.java
+++ b/scijava-common3/src/main/java/org/scijava/common3/Any.java
@@ -29,6 +29,7 @@
 
 package org.scijava.common3;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
@@ -122,6 +123,12 @@ public final class Any implements Type {
 		return true;
 	}
 
+	/**
+	 * Returns {@code true} iff {@code o} is an {@link Any}.
+	 *
+	 * @param o some {@link Object}
+	 * @return {@code true} iff {@code o} is an {@link Any}
+	 */
 	public static boolean is(Object o) {
 		return o instanceof Any || o.equals(Any.class);
 	}

--- a/scijava-common3/src/main/java/org/scijava/common3/Any.java
+++ b/scijava-common3/src/main/java/org/scijava/common3/Any.java
@@ -29,7 +29,6 @@
 
 package org.scijava.common3;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
#209 describes how persisting `Any`s within adaptation results in incorrect adaptor dependency matches. This PR resolves these issues by ignoring `Any`s matched to adaptor type variables.

For example, suppose we have an adaptor which can create a `Function<I, O>` given a `Computer<I, O>` and a `Producer<O>` (to create the pre-allocated output). We then want to use this adaptor to match a `Computer<I extends RealType<I>, O extends RealType<O>>` as a `Function<DoubleType, Any>`.

*Previously*, the adaptor would require a `Computer<DoubleType, Any>` (which usually is the correct match) and a `Producer<Any>` (which is usually an incorrect match as it will always be the highest-priority `engine.create` `Producer` Op), resulting in the error described in #209.

*Now*, when the adaptor finds some `Computer<I extends RealType<I>, O extends RealType<O>>`, it will match `I -> DoubleType`, but will **ignore** the `O -> Any`, and will try to find a `Producer<O extends RealType<O>>`, which is a valid input to the `Computer`. 

Closes #209