### PR TITLE
Add ReducedInfoTreeGenerator

### DIFF
--- a/scijava-ops-engine/src/main/java/module-info.java
+++ b/scijava-ops-engine/src/main/java/module-info.java
@@ -72,6 +72,7 @@ module org.scijava.ops.engine {
 	provides org.scijava.ops.engine.InfoTreeGenerator with
 		org.scijava.ops.engine.matcher.adapt.AdaptationInfoTreeGenerator,
 		org.scijava.ops.engine.impl.DefaultInfoTreeGenerator,
+		org.scijava.ops.engine.matcher.reduce.ReducedInfoTreeGenerator,
 		org.scijava.ops.engine.matcher.convert.ConvertedInfoTreeGenerator;
 
 	provides org.scijava.ops.api.OpEnvironment with

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/reduce/ReducedInfoTreeGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/reduce/ReducedInfoTreeGenerator.java
@@ -1,0 +1,50 @@
+
+package org.scijava.ops.engine.matcher.reduce;
+
+import org.scijava.ops.api.InfoTree;
+import org.scijava.ops.api.OpEnvironment;
+import org.scijava.ops.api.OpInfo;
+import org.scijava.ops.engine.InfoTreeGenerator;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * An {@link org.scijava.ops.engine.InfoTreeGenerator} that is used to generate
+ * {@link org.scijava.ops.api.InfoTree}s for {@link ReducedOpInfo}s.
+ *
+ * @author Gabriel Selzer
+ */
+public class ReducedInfoTreeGenerator implements InfoTreeGenerator {
+
+	@Override
+	public InfoTree generate(OpEnvironment env, String signature,
+		Map<String, OpInfo> idMap, Collection<InfoTreeGenerator> generators)
+	{
+		// Chop off the prefix on all ReducedOpInfos
+		var reductionPrefix = ReducedOpInfo.IMPL_DECLARATION //
+			+ ReducedOpInfo.PARAMS_REDUCED;
+		var prefixless = signature.substring(reductionPrefix.length());
+		// Find the number of parameters reduced
+		var numString = prefixless.substring(0, //
+			prefixless.indexOf(ReducedOpInfo.ORIGINAL_INFO));
+		var idx = Integer.parseInt(numString) - 1;
+
+		// Create an InfoTree from the original Info
+		var substring = signature.substring( //
+			signature.indexOf(ReducedOpInfo.ORIGINAL_INFO) //
+				+ ReducedOpInfo.ORIGINAL_INFO.length());
+		var original = InfoTreeGenerator.generateDependencyTree(env, substring,
+			idMap, generators);
+		// Reduce the original info, and build a new InfoTree from the proper
+		// ReducedInfo
+		var reductions = new ReducedOpInfoGenerator().generateInfosFrom(
+			original.info());
+		return new InfoTree(reductions.get(idx), original.dependencies());
+	}
+
+	@Override
+	public boolean canGenerate(String signature) {
+		return signature.startsWith(ReducedOpInfo.IMPL_DECLARATION);
+	}
+}

--- a/scijava-ops-engine/src/main/resources/META-INF/services/org.scijava.ops.engine.InfoTreeGenerator
+++ b/scijava-ops-engine/src/main/resources/META-INF/services/org.scijava.ops.engine.InfoTreeGenerator
@@ -2,4 +2,5 @@
 # Instead, modify and re-run <basedir>/bin/generate-meta-inf.sh from the top-level
 org.scijava.ops.engine.matcher.adapt.AdaptationInfoTreeGenerator
 org.scijava.ops.engine.impl.DefaultInfoTreeGenerator
+org.scijava.ops.engine.matcher.reduce.ReducedInfoTreeGenerator
 org.scijava.ops.engine.matcher.convert.ConvertedInfoTreeGenerator

--- a/scijava-ops-engine/templates/main/java/module-info.vm
+++ b/scijava-ops-engine/templates/main/java/module-info.vm
@@ -44,6 +44,7 @@ module org.scijava.ops.engine {
 	provides org.scijava.ops.engine.InfoTreeGenerator with
 		org.scijava.ops.engine.matcher.adapt.AdaptationInfoTreeGenerator,
 		org.scijava.ops.engine.impl.DefaultInfoTreeGenerator,
+		org.scijava.ops.engine.matcher.reduce.ReducedInfoTreeGenerator,
 		org.scijava.ops.engine.matcher.convert.ConvertedInfoTreeGenerator;
 
 	provides org.scijava.ops.api.OpEnvironment with


### PR DESCRIPTION
This PR adds an `InfoTreeGenerator` able to convert Reduced Op (i.e. Ops with some optional parameters omitted) signatures back into Reduced Ops.

~~Notably, this PR works upon assumptions, described within the javadoc of `ReducedInfoTreeGenerator`. I would appreciate on someone else (@hinerm?) signing off on them before merge.~~

~~I held off on creating a PR for this because I wanted to think more about if there was an easy "more correct" way to enable the desired behavior, but I do not believe this would be easily accomplished.~~

EDIT: I found a "better way" of doing things, that additionally fixes package cycles!