### PR TITLE
Replace script-maven-plugin -> maven-antrun-plugin

### DIFF
--- a/scijava-legacy/pom.xml
+++ b/scijava-legacy/pom.xml
@@ -249,59 +249,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -336,11 +300,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-benchmarks/pom.xml
+++ b/scijava-ops-benchmarks/pom.xml
@@ -259,59 +259,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -346,11 +310,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-engine/pom.xml
+++ b/scijava-ops-engine/pom.xml
@@ -293,59 +293,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -380,11 +344,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-flim/pom.xml
+++ b/scijava-ops-flim/pom.xml
@@ -284,59 +284,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -371,11 +335,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-image/pom.xml
+++ b/scijava-ops-image/pom.xml
@@ -470,59 +470,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -557,11 +521,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-opencv/pom.xml
+++ b/scijava-ops-opencv/pom.xml
@@ -245,59 +245,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -332,11 +296,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>

--- a/scijava-ops-tutorial/pom.xml
+++ b/scijava-ops-tutorial/pom.xml
@@ -256,59 +256,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>com.alexecollins.maven.plugin</groupId>
-				<artifactId>script-maven-plugin</artifactId>
-				<version>1.0.0</version>
+				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>union-metadata-indices</id>
+						<id>union-op-yaml</id>
 						<phase>process-test-classes</phase>
 						<goals>
-							<goal>execute</goal>
+							<goal>run</goal>
 						</goals>
 						<configuration>
-							<language>ruby</language>
-							<script>
-								# Append the source plugin annotations to the test plugin annotations
-								require 'set'
-
-								# Handle windows paths
-								basedir = '${project.basedir}'.gsub /\\+/, '\\\\'
-
-								# Reads plugin metadata into a set of strings, one per plugin declaration.
-								def read_plugins(path)
-								delim = 'UNIQUE-SEQUENCE-THAT-NO-PLUGIN-WILL-EVER-USE'
-								return File.exist?(path) ? File.read(path).sub('}{', '}' + delim + '{').split(delim).to_set : Set.new()
-								end
-
-								# Read in main and test scope plugin annotations.
-								['ops.yaml'].each do |pluginsPath|
-								mainPluginsPath = "#{basedir}/target/classes/#{pluginsPath}"
-								testPluginsPath = "#{basedir}/target/test-classes/#{pluginsPath}"
-								mainPlugins = read_plugins(mainPluginsPath)
-								testPlugins = read_plugins(testPluginsPath)
-
-								# Write out unioned plugin annotations to test scope plugin annotations.
-								# Without this, the test scope code does not know of the main scope plugins.
-								allPlugins = mainPlugins.union(testPlugins)
-								unless allPlugins.empty?()
-								require 'fileutils'
-								FileUtils.mkdir_p File.dirname(testPluginsPath)
-								File.write(testPluginsPath, allPlugins.to_a.join(''))
-								end
-								end
-							</script>
+							<target>
+								<concat destfile="${project.basedir}/target/test-classes/ops.yaml" append="true">
+									<fileset file="${project.basedir}/target/classes/ops.yaml" />
+								</concat>
+							</target>
 						</configuration>
 					</execution>
 				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.jruby</groupId>
-						<artifactId>jruby-complete</artifactId>
-						<version>9.2.11.1</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
@@ -343,11 +307,9 @@
 										-->
 										<pluginExecution>
 											<pluginExecutionFilter>
-												<groupId>com.alexecollins.maven.plugin</groupId>
-												<artifactId>script-maven-plugin</artifactId>
-												<versionRange>${script-maven-plugin.version}</versionRange>
+												<artifactId>maven-antrun-plugin</artifactId>
 												<goals>
-													<goal>execute</goal>
+													<goal>run</goal>
 												</goals>
 											</pluginExecutionFilter>
 											<action>


### PR DESCRIPTION
This switch makes copying `src` Ops into `target/test-classes/ops.yaml` possible with far less code, and solves some local issues I had with the Ruby dependency.

I additionally tested this code within `scijava-types`, to observe what happens when this code is called in projects without Ops, and the result is that *nothing happens*, which is what we'd want!

@ctrueden does this solve scijava/scijava#229?