### PR TITLE
Update WritingYourOwnOpPackage.md

### DIFF
--- a/docs/ops/doc/WritingYourOwnOpPackage.md
+++ b/docs/ops/doc/WritingYourOwnOpPackage.md
@@ -284,12 +284,10 @@ At compile time, the SciJava Ops Indexer will convert each `@implNote` annotatio
 
 #### Adding the SciJava Ops Indexer to your POM
 
-Ops written through Javadoc are discovered by the SciJava Ops Indexer, which creates a file `ops.yaml` containing all of the data needed to import each Op you declare.
+Ops written through Javadoc are discovered by the SciJava Ops Indexer, which creates an `ops.yaml` file containing all of the data needed to import each Op you declare.
 
 Until the SciJava Ops annotation processor is integrated into [pom-scijava](https://github.com/scijava/pom-scijava), developers must add the following block of code to the `build` section of their project POM:
 
-TODO: Replace with the pom-scijava version needed to grab this annotation processor.
-TODO: Replace the SciJava Ops Indexer version with the correct initial version
 ```xml
 <build>
     <plugins>
@@ -314,6 +312,7 @@ TODO: Replace the SciJava Ops Indexer version with the correct initial version
     </plugins>
 </build>
 ```
+**Note:** Replace the `<version>` property with the [latest release](https://maven.scijava.org/#nexus-search;quick~scijava-ops-indexer), or omit if using a [parent pom](https://github.com/scijava/pom-scijava) managing the indexer.
 
 #### Declaring Ops with the `@implNote` syntax
 
@@ -369,7 +368,7 @@ public class MyClassOp
      * @param arg1 the first argument to the Op
      * @param arg2 the first argument to the Op
      * @return the result of the Op
-	 */
+   */
 	@Override
     public Double apply(Double arg1, Double arg2) {
 		return null;
@@ -384,9 +383,11 @@ Note that the only supported functional interfaces that can be used without addi
     <dependency>
         <groupId>org.scijava</groupId>
         <artifactId>scijava-function</artifactId>
+				<version>1.0.0</version>
     </dependency>
 </dependencies>
 ```
+**Note:** Replace the `<version>` property with the [latest release](https://maven.scijava.org/#nexus-search;quick~scijava-function), or omit if using a [parent pom](https://github.com/scijava/pom-scijava) managing SciJava Function.
 
 #### Declaring Ops as Fields
 
@@ -400,7 +401,7 @@ public class MyOpCollection {
      * @input arg2 the second {@link Double}
      * @output arg2 the second {@link Double}
      * @implNote op names='my.op'
-	 */
+   */
     public final BiFunction<Double, Double, Double> myFieldOp =
         (arg1, arg2) -> {...computation...};
 	
@@ -413,16 +414,7 @@ To describe each Op parameter, add the following tags to its javadoc:
 * To describe a conatiner (for a computer Op), add the Javadoc tag `@container <parameter_name> <description>`
 * To describe a mutable input (for an inplace Op), add the Javadoc tag `@mutable <parameter_name> <description>`
 
-Note again that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
-
-```xml
-<dependencies>
-    <dependency>
-        <groupId>org.scijava</groupId>
-        <artifactId>scijava-function</artifactId>
-    </dependency>
-</dependencies>
-```
+Note again that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library, as mentioned above.
 
 ### YAML
 

--- a/docs/ops/doc/WritingYourOwnOpPackage.md
+++ b/docs/ops/doc/WritingYourOwnOpPackage.md
@@ -1,222 +1,8 @@
 # Writing Your Own Op Package
 
-Right now, there are two ways to write and expose your own Ops.
+This page is designed to be the first resource for those wishing to extend SciJava Ops with additional algorithms. To those who are reading it, we hope you contribute your own algorithms!
 
-## Ops Through Javadoc
-
-The recommended way to declare your Ops is through Javadoc. This approach requires no additional runtime dependencies&mdash;only a correctly formatted `@implNote` tag in the javadoc block of each routine you wish to make available as an Op, plus the scijava-ops-indexer annotation processor component present on your annotation processor path at compile time.
-
-### Adding the SciJava Ops Indexer to your POM
-
-Ops written through Javadoc are discovered by the SciJava Ops Indexer, which creates a file `ops.yaml` containing all of the data needed to import each Op you declare.
-
-Until the SciJava Ops annotation processor is integrated into [pom-scijava](https://github.com/scijava/pom-scijava), developers must add the following block of code to the `build` section of their project POM:
-
-TODO: Replace with the pom-scijava version needed to grab this annotation processor.
-TODO: Replace the SciJava Ops Indexer version with the correct initial version
-```xml
-<build>
-    <plugins>
-        <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <annotationProcessorPaths>
-                    <path>
-                        <groupId>org.scijava</groupId>
-                        <artifactId>scijava-ops-indexer</artifactId>
-                        <version>1.0.0</version>
-                    </path>
-                </annotationProcessorPaths>
-                <fork>true</fork>
-                <showWarnings>true</showWarnings>
-                <compilerArgs>
-                    <arg>-Ascijava.ops.parse=true</arg>
-                    <arg>-Ascijava.ops.opVersion="${project.version}"</arg>
-                </compilerArgs>
-            </configuration>
-        </plugin>
-    </plugins>
-</build>
-```
-
-### Declaring Ops with the `@implNote` syntax
-
-To declare a block of code as an Op, simply add the `@implNote` tag to that block's Javadoc. The `@implNote` schema for declaring Ops is as follows:
-
-```java
-/**
- * @implNote op names='<names>' [priority='<priority>']
- */
-```
-
-The arguments to the `@implNote op` syntax are described below:
-* `names='<names>'` provides the names that the Op will match. If you'd like this Op to be searchable under one name `foo.bar`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`.
-* `priority='<priority>'` provides a decimal-valued priority used to break ties when multiple Ops match a given Op request. *We advise against adding priorities unless you experience matching conflicts*. Op priorities should follow the SciJava Priority standards [insert link].
-
-### Declaring Ops as Methods
-
-Any `static` method can be easily declared as an Op by simply appending the `@implNote` tag to the method's Javadoc:
-
-```java
-/**
- * My static method, which is also an Op
- * @implNote op names='my.op'
- * @param arg1 the first argument to the method
- * @param arg2 the first argument to the method
- * @return the result of the method
- */
-public static Double myStaticMethodOp(Double arg1, Double arg2) {
-    ...computation here...
-}
-```
-Additional Op characteristics are specified by placing parentheticals **at the end** of `@param` tags:
-* If an Op input is allowed to be `null`, you can add `(nullable)` to the end. This tells SciJava Ops that your Op will function with our without that parameter.
-* If an Op is written as a computer, you must add `(container)` to the end of the `@param` tag corresponding to the preallocated output buffer parameter.
-* If an Op is written as an inplace, you must add `(mutable)` to the end of the `@param` tag corresponding to the mutable input parameter.
-
-### Declaring Ops as Classes
-
-Any `Class` implementing a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can be declared as an Op using the `@implNote` syntax within the Javadoc *of that class*, as shown in the example below:
-
-```java
-/**
- * My class, which is also an Op
- *
- * @implNote op names='my.op'
- */
-public class MyClassOp
-		implements java.util.function.BiFunction<Double, Double, Double>
-{
-
-	/**
-     * The functional method of my Op
-     * @param arg1 the first argument to the Op
-     * @param arg2 the first argument to the Op
-     * @return the result of the Op
-	 */
-	@Override
-    public Double apply(Double arg1, Double arg2) {
-		return null;
-	}
-}
-```
-
-Note that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
-
-```xml
-<dependencies>
-    <dependency>
-        <groupId>org.scijava</groupId>
-        <artifactId>scijava-function</artifactId>
-    </dependency>
-</dependencies>
-```
-
-### Declaring Ops as Fields
-
-Any `Field` whose type is a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can also be declared as an Op. Function Ops are useful for very simple Ops, such as [Lambda Expressions](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html) or [Method references](https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html). For `Field`s, the `@implNote` syntax should be placed on Javadoc on the Field, as shown below:
-
-```java
-public class MyOpCollection {
-
-	/**
-     * @input arg1 the first {@link Double}
-     * @input arg2 the second {@link Double}
-     * @output arg2 the second {@link Double}
-     * @implNote op names='my.op'
-	 */
-    public final BiFunction<Double, Double, Double> myFieldOp =
-        (arg1, arg2) -> {...computation...};
-	
-}
-```
-To describe each Op parameter, add the following tags to its javadoc:
-
-* To describe a pure input, add the Javadoc tag `@input <parameter_name> <description>`
-* To describe a pure output (for a function Op), add the Javadoc tag `@output <description>`
-* To describe a conatiner (for a computer Op), add the Javadoc tag `@container <parameter_name> <description>`
-* To describe a mutable input (for an inplace Op), add the Javadoc tag `@mutable <parameter_name> <description>`
-
-Note again that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
-
-```xml
-<dependencies>
-    <dependency>
-        <groupId>org.scijava</groupId>
-        <artifactId>scijava-function</artifactId>
-    </dependency>
-</dependencies>
-```
-
-## Ops using JPMS
-
-The other way to expose Ops is by using the [Java Platform Module System](https://www.oracle.com/corporate/features/understanding-java-9-modules.html). This mechanism is used to expose the Ops declared within SciJava Ops Engine, and may be preferred for its usage of plain Java mechanisms and strong type safety:
-
-In contrast to the Javadoc mechanism, all projects wishing to declare Ops using JPMS must add a dependency on the SciJava Ops SPI library:
-
-```xml
-<dependencies>
-    <dependency>
-        <groupId>org.scijava</groupId>
-        <artifactId>scijava-ops-spi</artifactId>
-    </dependency>
-</dependencies>
-```
-
-### Declaring Ops as Classes
-
-Using JPMS, Ops can be declared as Classes using the `OpClass` annotation and the `Op` interface, as shown below:
-
-```java
-@OpClass(names = "my.op")
-public class MyClassOp implements BiFunction<Double, Double, Double>, Op {
-	@Override
-    public Double apply(Double arg1, Double arg2) {
-      ...computation...
-    }
-}
-```
-Note the following:
-* The `@OpClass` annotation provides the names of the Op
-* The `BiFunction` interface determines the functional type of the Op
-* The `Op` interface allows us to declare the Class as a service using JPMS
-
-Below, we'll see how to expose the Op within the `module-info.java`.
-
-### Declaring Ops as Fields and Methods
-
-Using JPMS, Ops can be declared as Fields using the `OpField` annotation, or as Methods using the `OpMethod` annotation, within any class that implements the `OpCollection` interface. An example is shown below:
-
-```java
-public class MyOpCollection implements OpCollection {
-	@OpField(names="my.fieldOp")
-    public final BiFunction<Double, Double, Double> myFieldOp =
-        (arg1, arg2) -> {...computation...};
-	
-	@OpMethod(names="my.methodOp", type=BiFunction.class)
-    public Double myMethodOp(final Double arg1, final Double arg2) {
-      ...computation...
-    }
-}
-```
-Note the following:
-* The `OpCollection` interface allows us to declare the Class as a service using JPMS
-* The `@OpField` annotation declares the `Field` as an Op and also specifies the name(s) of the Op
-* The `@OpMethod` annotation declares the `Method` as an Op and also specifies the name(s) of the Op. **In addition**, it specifies the functional interface of the resulting Op.
-
-### Exposing the Ops to SciJava Ops using the `module-info.java`
-
-The last step of declaring Ops using JPMS is to declare them in a `module-info.java`, located in the root package directory of your project (`src/main/java` for Maven projects).
-
-For an example module `com.example.ops` declaring the above Ops, we use the [`provides...with`] syntax to declare our `Op`s and our `OpCollection`s:
-
-```java
-module com.example.ops {
-	provides org.scijava.ops.spi.Op with com.example.ops.MyClassOp;
-	
-	provides org.scijava.ops.spi.OpCollection with com.example.ops.MyOpCollection;
-}
-```
+You'll find this page organized into two broad sections. The first section describes some best practices that we believe Op authors should think about when writing their Ops. The second section describes concrete steps Op authors can take to actually write discoverable Ops.
 
 ## Best Practices
 
@@ -301,7 +87,7 @@ The `scijava-progress` module provides a mechanism for long-running tasks to des
 While all Ops emit "binary" progress (denoting each Op's beginning and end), your Op can provide richer updates by adding the `scijava-progress` module, providing user value for long-running Ops. To add progress to your Op, you must add the following steps to your Op:
 
 * Before any significant computation, add the line `Progress.defineTotal(long elements)` where `elements` is the number of "discrete packets" of computation.
-* At convenient spots within your Op, call `Progress.update()` to denote that one packet of computation has finished. 
+* At convenient spots within your Op, call `Progress.update()` to denote that one packet of computation has finished.
   * **Alternatively**, it may be more convenient or performant to call `Progress.update(long numElements)` to denote `numElements` packets have completed at once.
 
 ```java
@@ -444,3 +230,296 @@ ArrayImg<DoubleType> output = ...
 
 ops.op("neighborhood.op").input(input, shape).output(output).compute()
 ```
+
+### Best Practices for Java Ops
+
+The following set of best practices apply specifically to Ops written in Java:
+
+#### Write Ops as Methods or Fields
+
+If you're writing granular, reusable Ops, you'll likely have many small building block Ops containing executable code. To minimize boilerplate, we advise writing Ops as either Fields or Methods, depending upon the exact Op being written:
+
+**Use methods for:**
+* Ops with dependencies
+* Ops that have utility being called outside of the SciJava Ops framework
+
+**Use fields for:**
+* Ops with few lines of code
+
+Consider a simple Op calling a single (example) line of code: `list.add(1);`
+
+Here's the Op, written as a Field:
+```java
+public Inplace<List<Integer>> addOne = list -> list.add(1);
+```
+Pretty short, right? For comparison, here's the same Op, written as a method:
+
+```java
+public static void addOne(final List<Integer> list) {
+    list.add(1);
+}
+```
+The method adds two lines of boilerplate, *but* has the benefit of not needing the `Inplace` interface.
+
+Finally, here's the same Op written as a Class:
+
+```java
+public class AddOne implements Inplace<List<Integer>> {
+    public void mutate(List<Integer> list) {
+        list.add(1);
+    }
+}
+```
+
+Even more boilerplate means larger files and more lines of code to maintain; all of this is to say, use Fields and Methods when possible!
+
+## Writing Ops in Java
+Right now, there are two ways to write and expose Ops written in Java.
+
+### Javadoc
+
+The recommended way to declare your Ops is through Javadoc. This approach requires no additional runtime dependencies&mdash;only a correctly formatted `@implNote` tag in the javadoc block of each routine you wish to make available as an Op, plus the SciJava Ops Indexer annotation processor component present on your annotation processor path at compile time.
+
+At compile time, the SciJava Ops Indexer will convert each `@implNote` annotation into valid Op YAML.
+
+#### Adding the SciJava Ops Indexer to your POM
+
+Ops written through Javadoc are discovered by the SciJava Ops Indexer, which creates a file `ops.yaml` containing all of the data needed to import each Op you declare.
+
+Until the SciJava Ops annotation processor is integrated into [pom-scijava](https://github.com/scijava/pom-scijava), developers must add the following block of code to the `build` section of their project POM:
+
+TODO: Replace with the pom-scijava version needed to grab this annotation processor.
+TODO: Replace the SciJava Ops Indexer version with the correct initial version
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.scijava</groupId>
+                        <artifactId>scijava-ops-indexer</artifactId>
+                        <version>1.0.0</version>
+                    </path>
+                </annotationProcessorPaths>
+                <fork>true</fork>
+                <showWarnings>true</showWarnings>
+                <compilerArgs>
+                    <arg>-Ascijava.ops.parse=true</arg>
+                    <arg>-Ascijava.ops.opVersion="${project.version}"</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+#### Declaring Ops with the `@implNote` syntax
+
+To declare a block of code as an Op, simply add the `@implNote` tag to that block's Javadoc. The `@implNote` schema for declaring Ops is as follows:
+
+```java
+/**
+ * @implNote op names='<names>' [priority='<priority>']
+ */
+```
+
+The arguments to the `@implNote op` syntax are described below:
+* `names='<names>'` provides the names that the Op will match. If you'd like this Op to be searchable under one name `foo.bar`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`, you can use the argument `names='foo.bar'`. If you'd like your Op to be searchable using multiple names, you can use a comma-delimited list. For example, if you want your Op to be searchable under the names `foo.bar` and `foo.baz`, then you can use the argument `names='foo.bar,foo.baz'`.
+* `priority='<priority>'` provides a decimal-valued priority used to break ties when multiple Ops match a given Op request. *We advise against adding priorities unless you experience matching conflicts*. Op priorities should follow the SciJava Priority standards [insert link].
+
+#### Declaring Ops as Methods
+
+Any `static` method can be easily declared as an Op by simply appending the `@implNote` tag to the method's Javadoc:
+
+```java
+/**
+ * My static method, which is also an Op
+ * @implNote op names='my.op'
+ * @param arg1 the first argument to the method
+ * @param arg2 the first argument to the method
+ * @return the result of the method
+ */
+public static Double myStaticMethodOp(Double arg1, Double arg2) {
+    ...computation here...
+}
+```
+Additional Op characteristics are specified by placing parentheticals **at the end** of `@param` tags:
+* If an Op input is allowed to be `null`, you can add `(nullable)` to the end. This tells SciJava Ops that your Op will function with our without that parameter.
+* If an Op is written as a computer, you must add `(container)` to the end of the `@param` tag corresponding to the preallocated output buffer parameter.
+* If an Op is written as an inplace, you must add `(mutable)` to the end of the `@param` tag corresponding to the mutable input parameter.
+
+#### Declaring Ops as Classes
+
+Any `Class` implementing a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can be declared as an Op using the `@implNote` syntax within the Javadoc *of that class*, as shown in the example below:
+
+```java
+/**
+ * My class, which is also an Op
+ *
+ * @implNote op names='my.op'
+ */
+public class MyClassOp
+		implements java.util.function.BiFunction<Double, Double, Double>
+{
+
+	/**
+     * The functional method of my Op
+     * @param arg1 the first argument to the Op
+     * @param arg2 the first argument to the Op
+     * @return the result of the Op
+	 */
+	@Override
+    public Double apply(Double arg1, Double arg2) {
+		return null;
+	}
+}
+```
+
+Note that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.scijava</groupId>
+        <artifactId>scijava-function</artifactId>
+    </dependency>
+</dependencies>
+```
+
+#### Declaring Ops as Fields
+
+Any `Field` whose type is a `FunctionalInterface` (such as `java.util.function.Function`, `java.util.function.BiFunction`, `org.scijava.computers.Computers.Arity1`, etc.) can also be declared as an Op. Function Ops are useful for very simple Ops, such as [Lambda Expressions](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html) or [Method references](https://docs.oracle.com/javase/tutorial/java/javaOO/methodreferences.html). For `Field`s, the `@implNote` syntax should be placed on Javadoc on the Field, as shown below:
+
+```java
+public class MyOpCollection {
+
+	/**
+     * @input arg1 the first {@link Double}
+     * @input arg2 the second {@link Double}
+     * @output arg2 the second {@link Double}
+     * @implNote op names='my.op'
+	 */
+    public final BiFunction<Double, Double, Double> myFieldOp =
+        (arg1, arg2) -> {...computation...};
+	
+}
+```
+To describe each Op parameter, add the following tags to its javadoc:
+
+* To describe a pure input, add the Javadoc tag `@input <parameter_name> <description>`
+* To describe a pure output (for a function Op), add the Javadoc tag `@output <description>`
+* To describe a conatiner (for a computer Op), add the Javadoc tag `@container <parameter_name> <description>`
+* To describe a mutable input (for an inplace Op), add the Javadoc tag `@mutable <parameter_name> <description>`
+
+Note again that the only supported functional interfaces that can be used without additional dependencies are `java.util.function.Function` and `java.util.function.BiFunction` - if you'd like to write an Op requiring more than two inputs, or to write an Op that takes a pre-allocated output buffer, you'll need to depend on the SciJava Function library:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.scijava</groupId>
+        <artifactId>scijava-function</artifactId>
+    </dependency>
+</dependencies>
+```
+
+### YAML
+
+The SciJava Ops Indexer described above greatly simplifies the process of creating Op YAML descriptors. If for some reason you cannot use the SciJava Ops Indexer, you can manually curate Op YAML descriptors as well.
+
+Assuming your project is following Maven's [standard directory layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html), all Op descriptors should be placed within a file `ops.yaml` within the `src/main/resources` directory. Inside the file, each Op is described using the following structure:
+```yaml
+- op:
+    names: [your.op.name1, your.op.name2, ...] # Array of Strings
+    description: 'your Op description' # String
+    source: yourOpSource # String - see below
+    priority: 0.0 # Number
+    version: '1' # String
+    parameters: # Array of dictionaries - see below
+      - {
+          parameter type: INPUT, # String, one of: INPUT, CONTAINER, MUTABLE, OUTPUT
+          name: arg0, # String
+          description: '', # String
+          type: org.bytedeco.opencv.opencv_core.Mat # String
+        }
+      - {
+          parameter type: CONTAINER,
+          name: arg1,
+          description: '',
+          type: org.bytedeco.opencv.opencv_core.Mat
+        }
+      - ...
+    authors: [John Doe, Jane Doe] # Array of Strings
+    tags: { # Dictionary, containing parameters particular to this Op type - see below
+        type: Computer2 # String
+      }
+```
+
+Of particular note are the following sections:
+
+#### Source
+
+For **java objects**, the `source` will start with one of the following prefix, followed by a `:/`, followed by a [percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding) stringification of the Op (i.e. calling `toString()` on the object). Examples are shown below:
+
+| Op Written As: | Prefix       | Example                                                                                                                                                                                                                                                                                                                                                                                          |
+|----------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Method         | `javaMethod` | [`javaMethod:/org.scijava.ops.image.filter.gauss.Gaussians.gaussRAISingleSigma%28net.imglib2.RandomAccessibleInterval%2Cdouble%2Cnet.imglib2.outofbounds.OutOfBoundsFactory%2Cnet.imglib2.RandomAccessibleInterval%29`](https://github.com/scijava/scijava/blob/b3917b2c7d1b403aa648b43071a229a7f2bcab5f/scijava-ops-image/src/main/java/org/scijava/ops/image/filter/gauss/Gaussians.java#L114) |
+| Field          | `javaField`  | [`javaField:/org.scijava.ops.image.types.maxValue.MaxValueRealTypes%24maxBitType`](https://github.com/scijava/scijava/blob/b3917b2c7d1b403aa648b43071a229a7f2bcab5f/scijava-ops-image/src/main/java/org/scijava/ops/image/types/maxValue/MaxValueRealTypes.java#L71)                                                                                                                             |
+| Class          | `javaClass`  | [`javaClass:/org.scijava.ops.image.filter.FFTMethodsLinearFFTFilterC`](https://github.com/scijava/scijava/blob/b3917b2c7d1b403aa648b43071a229a7f2bcab5f/scijava-ops-image/src/main/java/org/scijava/ops/image/filter/FFTMethodsLinearFFTFilterC.java#L53)                                                                                                                                        |
+
+#### Parameters
+
+For **java objects**, the `parameter`s array should contain one entry for each parameter and return in the **functional method** of the Op. For example, given the below Op, there should be three parameter dictionaries. The first should describe the `INPUT` `String` parameter `foo`, the second the `INPUT` `Integer` parameter `bar`, and the third the `OUTPUT` `Double` return parameter.
+
+```java
+public static Double someOp(String foo, Integer bar) {...}
+```
+
+yielding the following YAML:
+```yaml
+    parameters: 
+      - {
+        parameter type: INPUT,
+        name: foo,
+        nullable: false,
+        description: '',
+        type: java.lang.String
+      }
+      - {
+        parameter type: INPUT,
+        name: bar,
+        nullable: false,
+        description: '',
+        type: java.lang.Integer
+      }
+      - {
+        parameter type: OUTPUT,
+        name: output,
+        nullable: false,
+        description: '',
+        type: java.lang.Double
+      }
+```
+
+The following table describes each valid key-value pair in a `parameters` entry:
+
+| Key            | Value Type                                            | Required?            |
+|----------------|-------------------------------------------------------|----------------------|
+| name           | String                                                | Yes                  |
+| description    | String                                                | Yes                  |
+| parameter type | String (`INPUT`, `CONTAINER`, `MUTABLE`, or `OUTPUT`) | Yes                  |
+| type           | String (stringification of some Java `Type`)          | Yes                  |
+| nullable       | boolean                                               | No (default `false`) |
+
+#### Tags
+
+The `tags` dictionary contains parameters that pertain only to a specific kind of Op (e.g. parameters that are only relevant for Ops written as Java methods). 
+
+**Method Tags**:
+* `type` - a String denoting the functional interface that the method conforms to. Can be:
+  * A fully qualified `FunctionalInterface` class name
+  * `Function`, if the method corresponds to a `Function` Op
+  * `Computer`, if the method corresponds to a `Computer` Op
+  * `InplaceN`, if the method corresponds to an `Inplace` Op where the Nth (1-indexed) method parameter is mutable
+  * `ComputerN`, if the method corresponds to a `Computer` Op where the Nth (1-indexed) method parameter is the container


### PR DESCRIPTION
This PR makes the following alterations (mostly suggested by @ctrueden) to the [Writing Your Own Op Package](https://ops.scijava.org/en/latest/WritingYourOwnOpPackage.html) page of the documentation:
* Moving the "Best Practices" section of the document to the top, because it really applies to all Ops
* Reorganizing the discovery mechanisms by language, in preparation for future mechanisms operating on other languages 🪄 
* Writing a new section for explicit YAML curation (I know, it's not something we'd want to force on people, but I also don't think the YAML format is actually documented anywhere. Maybe it deserves its own page?)
* Adding a disclaimer to the JPMS section that it will be phased out (see #140)

Original list of updates wanted by @ctrueden (I didn't really do either of these, feel free to alter this PR as you see fit!):
* [ ] prefer Javadoc over JPMS declaration style
* [ ] prefer @OpField for succinctness, or @OpMethod over @OpClass if Op dependencies are needed, to minimize boilerplate