### PR TITLE
Expose Hints via Javadoc

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,7 +1,6 @@
 name: scijava-docs
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - myst-nb
   - openjdk=11

--- a/docs/ops/doc/WritingYourOwnOpPackage.md
+++ b/docs/ops/doc/WritingYourOwnOpPackage.md
@@ -467,6 +467,7 @@ Assuming your project is following Maven's [standard directory layout](https://m
 ```yaml
 - op:
     names: [your.op.name1, your.op.name2, ...] # Array of Strings
+    hints: [op.hint1, op.hint2, ...] # Array of Strings
     description: 'your Op description' # String
     source: yourOpSource # String - see below
     priority: 0.0 # Number
@@ -492,6 +493,17 @@ Assuming your project is following Maven's [standard directory layout](https://m
 ```
 
 Of particular note are the following sections:
+
+#### Hints
+
+Each Op can define a set of hints (i.e. flags to the matcher) that can enable/disable particular aspects of the matcher.
+
+Some of the most useful Op hints are described below:
+
+| Hint                   | Use Case                                                                                                                                                                                                                                                              |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Adaptation.FORBIDDEN` | Some algorithms like a [Fast Fourier Transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform) require their outputs be <br>of a particular size (not equivalent to the input size). If they are a `Computer`, <br>adaptation to `Function`s may cause errors. |
+| `Conversion.FORBIDDEN` | `engine.convert` Ops often require this hint to avoid infinite loops in <br>converted Op matching.                                                                                                                                                                    |
 
 #### Source
 

--- a/scijava-ops-api/src/main/java/org/scijava/ops/api/Hints.java
+++ b/scijava-ops-api/src/main/java/org/scijava/ops/api/Hints.java
@@ -62,7 +62,7 @@ public class Hints {
 		this(Arrays.asList(startingHints));
 	}
 
-	private Hints(final Collection<String> hints) {
+	public Hints(final Collection<String> hints) {
 		this.hints = new HashSet<>(hints);
 	}
 

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/AbstractYAMLOpInfo.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/yaml/impl/AbstractYAMLOpInfo.java
@@ -35,8 +35,8 @@ import org.scijava.ops.engine.util.Infos;
 import org.scijava.priority.Priority;
 import org.scijava.struct.Struct;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +59,10 @@ public abstract class AbstractYAMLOpInfo implements OpInfo {
 		this.priority = parsePriority();
 		this.description = yaml.getOrDefault("description", "").toString();
 		this.version = (String) yaml.get("version");
-		this.hints = new Hints();
+		this.hints = new Hints((List<String>) yaml.getOrDefault( //
+				"hints", //
+				Collections.emptyList() //
+		));
 	}
 
 	/**

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/YAMLOpTest.java
@@ -121,4 +121,16 @@ public class YAMLOpTest extends AbstractTestEnvironment {
 		Assertions.assertEquals(expected, actual);
 	}
 
+	@Test
+	public void testYAMLHints() {
+		var infos = ops.infos("example.xor");
+		Assertions.assertEquals(1, infos.size());
+		var info = infos.iterator().next();
+		var hints = info.declaredHints();
+		Assertions.assertTrue(hints.containsAll( //
+				"Adaptation.FORBIDDEN", //
+				"Conversion.FORBIDDEN" //
+		));
+	}
+
 }

--- a/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/ops/YAMLMethodOp.java
+++ b/scijava-ops-engine/src/test/java/org/scijava/ops/engine/yaml/impl/ops/YAMLMethodOp.java
@@ -57,7 +57,7 @@ public class YAMLMethodOp {
 	/**
 	 * Another example Op, implemented by a {@link Method}
 	 *
-	 * @implNote op name=example.xor, type=Inplace1
+	 * @implNote op name=example.xor, type=Inplace1, hints="Adaptation.FORBIDDEN,Conversion.FORBIDDEN"
 	 * @param aList the first integer {@link List}
 	 * @param aList2 the second integer {@link List}
 	 */

--- a/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/OpImplData.java
+++ b/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/OpImplData.java
@@ -29,15 +29,14 @@
 
 package org.scijava.ops.indexer;
 
-import static org.scijava.ops.indexer.ProcessingUtils.blockSeparator;
-import static org.scijava.ops.indexer.ProcessingUtils.tagElementSeparator;
-
 import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
+
+import static org.scijava.ops.indexer.ProcessingUtils.*;
 
 /**
  * A data structure containing all the metadata needed to define an Op
@@ -88,6 +87,11 @@ abstract class OpImplData {
 	 * A {@link List} of the authors of this Op
 	 */
 	protected final List<String> authors = new ArrayList<>();
+
+	/**
+	 * A {@link List} of the hints declared by this Op
+	 */
+	protected final List<String> hints = new ArrayList<>();
 
 	protected final ProcessingEnvironment env;
 
@@ -186,6 +190,10 @@ abstract class OpImplData {
 					else if ("names".equals(kv[0]) || "name".equals(kv[0])) {
 						names.addAll(Arrays.asList(value.split("\\s*,\\s*")));
 					}
+					else if ("hints".equals(kv[0])) {
+
+						hints.addAll(Arrays.asList(value.split("\\s*,\\s*")));
+					}
 					else {
 						if (value.contains(",")) {
 							tags.put(kv[0], value.split(","));
@@ -216,6 +224,7 @@ abstract class OpImplData {
 		map.put("description", description);
 		map.put("priority", priority);
 		map.put("authors", authors.toArray(String[]::new));
+		map.put("hints", hints.toArray(String[]::new));
         var foo = params.stream() //
 			.map(OpParameter::data) //
 			.collect(Collectors.toList());

--- a/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/ProcessingUtils.java
+++ b/scijava-ops-indexer/src/main/java/org/scijava/ops/indexer/ProcessingUtils.java
@@ -65,7 +65,7 @@ final class ProcessingUtils {
 	 * tags.
 	 */
 	public static final Pattern tagElementSeparator = Pattern.compile(
-		"\\s*[,\\s]+(?=(?:[^']*'[^']*')*[^']*$)");
+		"\\s*[,\\s]+(?=(?:[^'\"]*['\"][^'\"]*['\"])*[^'\"]*$)");
 
 	private ProcessingUtils() {
 		throw new AssertionError("not instantiable");


### PR DESCRIPTION
Closes #256 by allowing developers to add hints to the `@implNote` annotation. 

Notably, this introduces new API, as I made the `private Hints(Collection<String>)` constructor `public`. @ctrueden shall we bump SciJava Ops API then to 1.1.0?