### PR TITLE
Improve docs build instructions + sample image download links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,41 @@
-# Adding a new ReadTheDocs page for a project in this repository
+This directory houses the online docs for core SciJava components. Each subfolder is its own ReadTheDocs site.
+
+## Building the docs
+
+If this is your first time building the docs on this machine, create the needed environment with:
+
+```shell
+mamba env create -f environment.yml
+```
+
+Subsequently, every time you want to build, run the following commands:
+
+```
+mamba activate scijava-docs
+make clean html && python -m http.server
+```
+
+If all goes well, you'll see output ending like:
+```
+The HTML pages are in _build/scijava-ops/html.
+Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+```
+
+To view the built site, open the HTTP link in your browser of choice, then navigate to the stated subdirectory.
+
+## Adding a new ReadTheDocs page for a project in this repository
 
 We use [`sphinx-multiproject`](https://sphinx-multiproject.readthedocs.io/en/latest/index.html) to build multiple RTD sites from within a single repository. To add a new site within this repository, take the following steps:
 
-## Create a new subfolder for the site's documents
+### Create a new subfolder for the site's documents
 
 See the existing `ops` folder for a template.
 
-## Add relevant sections to this folder's `conf.py`
+### Add relevant sections to this folder's `conf.py`
 
 Specifically, you'll want to add an entry to the `multiproject_projects` dictionary. Again, you can copy and edit the `ops` entry.
 
-## Create a new project on `ReadTheDocs`
+### Create a new project on `ReadTheDocs`
 
 You'll want to take the following steps:
 1. Choose to import a project manually

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: scijava-docs-ops
+name: scijava-docs
 channels:
   - conda-forge
   - defaults

--- a/docs/ops/doc/examples/deconvolution.rst
+++ b/docs/ops/doc/examples/deconvolution.rst
@@ -8,7 +8,12 @@ The SciJava Ops framework currently supports the standard RL algorithm as well a
 algorithm, which utilizes a regularization factor to limit the noise amplified by the RL algorithm :sup:`1`. Typically,
 the RLTV algorithm returns improved axial and lateral resolution when compared to RL.
 
-You can download the 3D HeLa cell nuclus dataset `here`_.
+You can download the 3D HeLa cell nucleus dataset here:
+
+.. admonition:: Download
+   :class: note
+
+   `hela_nucleus.tif`_
 
 .. figure:: https://media.scijava.org/scijava-ops/1.0.0/rltv_example_1.gif
 
@@ -145,5 +150,5 @@ SciJava Ops via Fiji's scripting engine with `script parameters`_:
 
 .. _`Dey et. al, Micros Res Tech 2006`: https://pubmed.ncbi.nlm.nih.gov/16586486/
 .. _`Gibson & Lanni, JOSA 1992`: https://pubmed.ncbi.nlm.nih.gov/1738047/
-.. _`here`: https://media.scijava.org/scijava-ops/1.0.0/hela_nucleus.tif
+.. _`hela_nucleus.tif`: https://media.scijava.org/scijava-ops/1.0.0/hela_nucleus.tif
 .. _`script parameters`: https://imagej.net/scripting/parameters

--- a/docs/ops/doc/examples/opencv_denoise.rst
+++ b/docs/ops/doc/examples/opencv_denoise.rst
@@ -9,7 +9,12 @@ a pixel of interest (*e.g.* a 5x5 patch) with patches from other pixels from the
 patches are then averaged to eliminate gaussian noise, without the requirement of additional
 images for comparison.
 
-The sample data for this example can be downloaded `here`_.
+The sample data for this example can be downloaded here:
+
+.. admonition:: Download
+   :class: note
+
+   `opencv_denoise_16bit.tif`_
 
 .. figure:: https://media.scijava.org/scijava-ops/1.0.0/opencv_denoise_example_1.png
 
@@ -121,4 +126,4 @@ SciJava Ops via Fiji's scripting engine with `script parameters`_:
 
 .. _`script parameters`: https://imagej.net/scripting/parameters
 .. _`OpenCV library`: https://docs.opencv.org/4.x/d5/d69/tutorial_py_non_local_means.html
-.. _`here`: https://media.scijava.org/scijava-ops/1.0.0/opencv_denoise_16bit.tif
+.. _`opencv_denoise_16bit.tif`: https://media.scijava.org/scijava-ops/1.0.0/opencv_denoise_16bit.tif

--- a/docs/ops/doc/examples/saca.rst
+++ b/docs/ops/doc/examples/saca.rst
@@ -17,7 +17,12 @@ can be computed easily by using the *Z*-score heatmap with the ``stats.pnorm`` O
 significantly colocalized. This example script takes advantage of this feature of the SACA framework and utilizes the significant pixel
 mask as a region of interest to compute Pearson's :sup:`4` and Li's :sup:`5` colocalization coefficients.
 
-You can download the colocalization dataset `here`_.
+You can download the colocalization dataset here:
+
+.. admonition:: Download
+   :class: note
+
+   `hela_hiv_gag_ms2_mcherry.tif`_
 
 .. figure:: https://media.scijava.org/scijava-ops/1.0.0/saca_input.png
 
@@ -169,5 +174,5 @@ To apply the ``phase`` LUT and a colorbar use the following script and select th
 .. _`Becker and Sherer, JVI 2017`: https://pubmed.ncbi.nlm.nih.gov/28053097/
 .. _`Wang et. al, IEEE 2019`: https://ieeexplore.ieee.org/abstract/document/8681436
 .. _`Stockley et. al, Bacteriophage 2016`: https://pubmed.ncbi.nlm.nih.gov/27144089/
-.. _`here`: https://media.scijava.org/scijava-ops/1.0.0/hela_hiv_gag_ms2_mcherry.tif
+.. _`hela_hiv_gag_ms2_mcherry.tif`: https://media.scijava.org/scijava-ops/1.0.0/hela_hiv_gag_ms2_mcherry.tif
 .. _`script parameters`: https://imagej.net/scripting/parameters

--- a/docs/ops/doc/examples/volume_labeling.rst
+++ b/docs/ops/doc/examples/volume_labeling.rst
@@ -21,7 +21,14 @@ to accomplish this analysis goal the script utilizes SciJava Ops to:
 5. Measure the 3D geometry of the puncta and nuclear regions.
 6. Display results in two tables (puncta and nuclear).
 
-To use the script in the example first download the sample dataset `here`_. Next, open Fiji, the sample image and this scipt. Click **Run** to create the script parameter GUI,
+To use the script in the example, first download the sample dataset:
+
+.. admonition:: Download
+   :class: note
+
+   `hela_hiv_vif.tif`_
+
+Next, open Fiji, the sample image and this script. Click **Run** to create the script parameter GUI,
 where you can customize some values to your own data, such as the channel names, channel position and image calibration values.
 
 .. figure:: https://media.scijava.org/scijava-ops/1.1.0/labeling_mesh_example_dialog.png
@@ -295,4 +302,4 @@ In addition to the result tables, the label imdage (also known as an *index imag
         ui.show("{} results table".format(ch_a_name), ab_table)
         ui.show("{} results table".format(ch_b_name), b_table)
 
-.. _`here`: https://media.scijava.org/scijava-ops/1.0.0/hela_hiv_vif.tif
+.. _`hela_hiv_vif.tif`: https://media.scijava.org/scijava-ops/1.0.0/hela_hiv_vif.tif


### PR DESCRIPTION
- **Move scijava docs environment to base docs folder**
- **Add instructions for building the docs locally**
- **Make the sample image download links clearer**
