### PR TITLE
engine.wrap Ops

### DIFF
--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/Conversions.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/Conversions.java
@@ -241,8 +241,8 @@ public final class Conversions {
 			return Optional.empty();
 		}
 		// And only applies when the mutable index was "converted" with identity
-		if (Ops.info(preConverters.get(ioIndex)).names().contains(
-			"engine.identity"))
+		var names = Ops.info(preConverters.get(ioIndex)).names();
+		if (names.contains("engine.identity") || names.contains("engine.wrap"))
 		{
 			// In this case, we need neither a postprocessor nor a copier,
 			// because the mutable output was directly edited.

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedInfoTreeGenerator.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/convert/ConvertedInfoTreeGenerator.java
@@ -39,6 +39,8 @@ import org.scijava.function.Computers;
 import org.scijava.ops.api.*;
 import org.scijava.ops.engine.BaseOpHints;
 import org.scijava.ops.engine.InfoTreeGenerator;
+import org.scijava.ops.engine.matcher.impl.DefaultOpRequest;
+import org.scijava.ops.engine.matcher.impl.InfoMatchingOpRequest;
 import org.scijava.types.Nil;
 
 /**

--- a/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/RuntimeSafeMatchingRoutine.java
+++ b/scijava-ops-engine/src/main/java/org/scijava/ops/engine/matcher/impl/RuntimeSafeMatchingRoutine.java
@@ -53,7 +53,6 @@ import org.scijava.ops.engine.matcher.MatchingRoutine;
 import org.scijava.ops.engine.matcher.OpMatcher;
 import org.scijava.ops.engine.matcher.impl.MatchingUtils.TypeVarInfo;
 import org.scijava.priority.Priority;
-import org.scijava.struct.Member;
 import org.scijava.common3.Types;
 import org.scijava.types.infer.GenericAssignability;
 

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/ConvertImages.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/ConvertImages.java
@@ -59,404 +59,404 @@ import java.util.function.BiFunction;
  */
 public final class ConvertImages {
 
-	/**
-	 * @implNote op names='convert.bit, engine.convert', type=Function
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}s
-	 *         values but whose element types are {@link BitType}s.
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<BitType> typeToBit(final RAIC input)
-	{
-		final C ZERO = Util.getTypeFromInterval(input).createVariable();
-		ZERO.setZero();
-		final C ONE = Util.getTypeFromInterval(input).createVariable();
-		ONE.setOne();
+//	/**
+//	 * @implNote op names='convert.bit, engine.convert', type=Function
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}s
+//	 *         values but whose element types are {@link BitType}s.
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<BitType> typeToBit(final RAIC input)
+//	{
+//		final C ZERO = input.firstElement().createVariable();
+//		ZERO.setZero();
+//		final C ONE = input.firstElement().createVariable();
+//		ONE.setOne();
+//
+//		return Converters.convert(input, sampler -> new BitType(new LongAccess() {
+//			@Override
+//			public long getValue(int index) {
+//				return sampler.get().equals(ZERO) ? 0L : 1L;
+//			}
+//
+//			@Override
+//			public void setValue(int index, long value) {
+//				if (value == 0L) {
+//					sampler.get().set(ZERO);
+//				} else {
+//					sampler.get().set(ONE);
+//				}
+//			}
+//		}));
+//	}
 
-		return Converters.convert(input, sampler -> new BitType(new LongAccess() {
-			@Override
-			public long getValue(int index) {
-				return sampler.get().equals(ZERO) ? 0L : 1L;
-			}
-
-			@Override
-			public void setValue(int index, long value) {
-				if (value == 0L) {
-					sampler.get().set(ZERO);
-				} else {
-					sampler.get().set(ONE);
-				}
-			}
-		}));
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link Unsigned2BitType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link Unsigned2BitType}s.
-	 * @implNote op names='convert.uint2, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<Unsigned2BitType> typeToUnsigned2Bit(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, Unsigned2BitType, RandomAccessibleInterval<Unsigned2BitType>> creator,
-			@OpDependency(
-				name = "convert.uint2") Computers.Arity1<C, Unsigned2BitType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new Unsigned2BitType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link Unsigned4BitType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link Unsigned4BitType}s.
-	 * @implNote op names='convert.uint4, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<Unsigned4BitType> typeToUnsigned4Bit(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, Unsigned4BitType, RandomAccessibleInterval<Unsigned4BitType>> creator,
-			@OpDependency(
-				name = "convert.uint4") Computers.Arity1<C, Unsigned4BitType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new Unsigned4BitType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link ByteType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link ByteType}s.
-	 * @implNote op names='convert.int8, convert.byte, engine.convert',
-	 *           type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<ByteType> typeToByte(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, ByteType, RandomAccessibleInterval<ByteType>> creator,
-			@OpDependency(
-				name = "convert.int8") Computers.Arity1<C, ByteType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new ByteType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link UnsignedByteType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link UnsignedByteType}s.
-	 * @implNote op names='convert.uint8, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<UnsignedByteType> typeToUnsignedByte(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, UnsignedByteType, RandomAccessibleInterval<UnsignedByteType>> creator,
-			@OpDependency(
-				name = "convert.uint8") Computers.Arity1<C, UnsignedByteType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new UnsignedByteType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link Unsigned12BitType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link Unsigned12BitType}s.
-	 * @implNote op names='convert.uint12, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<Unsigned12BitType> typeToUnsigned12Bit(
-			@OpDependency(
-				name = "create.img") BiFunction<Dimensions, Unsigned12BitType, RandomAccessibleInterval<Unsigned12BitType>> creator,
-			@OpDependency(
-				name = "convert.uint12") Computers.Arity1<C, Unsigned12BitType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new Unsigned12BitType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link ShortType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link ShortType}s.
-	 * @implNote op names='convert.int16, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<ShortType> typeToShort(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, ShortType, RandomAccessibleInterval<ShortType>> creator,
-			@OpDependency(
-				name = "convert.int16") Computers.Arity1<C, ShortType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new ShortType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link UnsignedShortType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link UnsignedShortType}s.
-	 * @implNote op names='convert.uint16, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<UnsignedShortType> typeToUnsignedShort(
-			@OpDependency(
-				name = "create.img") BiFunction<Dimensions, UnsignedShortType, RandomAccessibleInterval<UnsignedShortType>> creator,
-			@OpDependency(
-				name = "convert.uint16") Computers.Arity1<C, UnsignedShortType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new UnsignedShortType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link IntType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link IntType}s.
-	 * @implNote op names='convert.int32, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<IntType> typeToInt(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, IntType, RandomAccessibleInterval<IntType>> creator,
-			@OpDependency(
-				name = "convert.int32") Computers.Arity1<C, IntType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new IntType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link UnsignedIntType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link UnsignedIntType}s.
-	 * @implNote op names='convert.uint32, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<UnsignedIntType> typeToUnsignedInt(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, UnsignedIntType, RandomAccessibleInterval<UnsignedIntType>> creator,
-			@OpDependency(
-				name = "convert.uint32") Computers.Arity1<C, UnsignedIntType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new UnsignedIntType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link LongType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link LongType}s.
-	 * @implNote op names='convert.int64, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<LongType> typeToLong(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, LongType, RandomAccessibleInterval<LongType>> creator,
-			@OpDependency(
-				name = "convert.int64") Computers.Arity1<C, LongType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new LongType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link UnsignedLongType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link UnsignedLongType}s.
-	 * @implNote op names='convert.uint64, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<UnsignedLongType> typeToUnsignedLong(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, UnsignedLongType, RandomAccessibleInterval<UnsignedLongType>> creator,
-			@OpDependency(
-				name = "convert.uint64") Computers.Arity1<C, UnsignedLongType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new UnsignedLongType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link Unsigned128BitType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link Unsigned128BitType}s.
-	 * @implNote op names='convert.uint128, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<Unsigned128BitType> typeToUnsigned128Bit(
-			@OpDependency(
-				name = "create.img") BiFunction<Dimensions, Unsigned128BitType, RandomAccessibleInterval<Unsigned128BitType>> creator,
-			@OpDependency(
-				name = "convert.uint128") Computers.Arity1<C, Unsigned128BitType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new Unsigned128BitType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link FloatType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link FloatType}s.
-	 * @implNote op names='convert.float32, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<FloatType> typeToFloat32(@OpDependency(
-			name = "create.img") BiFunction<Dimensions, FloatType, RandomAccessibleInterval<FloatType>> creator,
-			@OpDependency(
-				name = "convert.float32") Computers.Arity1<C, FloatType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new FloatType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param creator a {@link BiFunction} to create the output image
-	 * @param converter a {@link Computers.Arity1} to convert the type to a
-	 *          {@link ComplexFloatType}
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link ComplexFloatType}s.
-	 * @implNote op names='convert.cfloat32, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<ComplexFloatType> typeToComplexFloat32(
-			@OpDependency(
-				name = "create.img") BiFunction<Dimensions, ComplexFloatType, RandomAccessibleInterval<ComplexFloatType>> creator,
-			@OpDependency(
-				name = "convert.cfloat32") Computers.Arity1<C, ComplexFloatType> converter,
-			final RAIC input)
-	{
-        var output = creator.apply(input,
-			new ComplexFloatType());
-		LoopBuilder.setImages(input, output).forEachPixel(converter);
-		return output;
-	}
-
-	/**
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link DoubleType}s.
-	 * @implNote op names='convert.float64, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<DoubleType> typeToDoubleType(final RAIC input)
-	{
-		return Converters.convert(input, sampler -> new DoubleType(new DoubleAccess() {
-
-			@Override
-			public double getValue(int index) {
-				return sampler.get().getRealDouble();
-			}
-
-			@Override
-			public void setValue(int index, double value) {
-				sampler.get().setReal(value);
-				sampler.get().setImaginary(0);
-			}
-		}));
-	}
-
-	/**
-	 * @param input the input image
-	 * @return an output image whose values are equivalent to {@code input}'s
-	 *         values but whose element types are {@link ComplexDoubleType}s.
-	 * @implNote op names='convert.cfloat64, engine.convert', type=Function
-	 */
-	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
-		RandomAccessibleInterval<ComplexDoubleType> typeToComplexDouble32(
-			final RAIC input)
-	{
-		return Converters.convert(input, sampler -> new ComplexDoubleType(new DoubleAccess() {
-
-			@Override
-			public double getValue(int index) {
-				if (index % 2 == 0) {
-					return sampler.get().getRealDouble();
-				} else {
-					return sampler.get().getImaginaryDouble();
-				}
-			}
-
-			@Override
-			public void setValue(int index, double value) {
-				if (index % 2 == 0) {
-					sampler.get().setReal(value);
-				} else {
-					sampler.get().setImaginary(value);
-				}
-			}
-		}));
-	}
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link Unsigned2BitType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link Unsigned2BitType}s.
+//	 * @implNote op names='convert.uint2, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<Unsigned2BitType> typeToUnsigned2Bit(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, Unsigned2BitType, RandomAccessibleInterval<Unsigned2BitType>> creator,
+//			@OpDependency(
+//				name = "convert.uint2") Computers.Arity1<C, Unsigned2BitType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new Unsigned2BitType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link Unsigned4BitType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link Unsigned4BitType}s.
+//	 * @implNote op names='convert.uint4, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<Unsigned4BitType> typeToUnsigned4Bit(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, Unsigned4BitType, RandomAccessibleInterval<Unsigned4BitType>> creator,
+//			@OpDependency(
+//				name = "convert.uint4") Computers.Arity1<C, Unsigned4BitType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new Unsigned4BitType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link ByteType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link ByteType}s.
+//	 * @implNote op names='convert.int8, convert.byte, engine.convert',
+//	 *           type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<ByteType> typeToByte(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, ByteType, RandomAccessibleInterval<ByteType>> creator,
+//			@OpDependency(
+//				name = "convert.int8") Computers.Arity1<C, ByteType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new ByteType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link UnsignedByteType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link UnsignedByteType}s.
+//	 * @implNote op names='convert.uint8, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<UnsignedByteType> typeToUnsignedByte(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, UnsignedByteType, RandomAccessibleInterval<UnsignedByteType>> creator,
+//			@OpDependency(
+//				name = "convert.uint8") Computers.Arity1<C, UnsignedByteType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new UnsignedByteType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link Unsigned12BitType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link Unsigned12BitType}s.
+//	 * @implNote op names='convert.uint12, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<Unsigned12BitType> typeToUnsigned12Bit(
+//			@OpDependency(
+//				name = "create.img") BiFunction<Dimensions, Unsigned12BitType, RandomAccessibleInterval<Unsigned12BitType>> creator,
+//			@OpDependency(
+//				name = "convert.uint12") Computers.Arity1<C, Unsigned12BitType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new Unsigned12BitType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link ShortType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link ShortType}s.
+//	 * @implNote op names='convert.int16, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<ShortType> typeToShort(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, ShortType, RandomAccessibleInterval<ShortType>> creator,
+//			@OpDependency(
+//				name = "convert.int16") Computers.Arity1<C, ShortType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new ShortType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link UnsignedShortType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link UnsignedShortType}s.
+//	 * @implNote op names='convert.uint16, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<UnsignedShortType> typeToUnsignedShort(
+//			@OpDependency(
+//				name = "create.img") BiFunction<Dimensions, UnsignedShortType, RandomAccessibleInterval<UnsignedShortType>> creator,
+//			@OpDependency(
+//				name = "convert.uint16") Computers.Arity1<C, UnsignedShortType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new UnsignedShortType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link IntType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link IntType}s.
+//	 * @implNote op names='convert.int32, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<IntType> typeToInt(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, IntType, RandomAccessibleInterval<IntType>> creator,
+//			@OpDependency(
+//				name = "convert.int32") Computers.Arity1<C, IntType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new IntType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link UnsignedIntType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link UnsignedIntType}s.
+//	 * @implNote op names='convert.uint32, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<UnsignedIntType> typeToUnsignedInt(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, UnsignedIntType, RandomAccessibleInterval<UnsignedIntType>> creator,
+//			@OpDependency(
+//				name = "convert.uint32") Computers.Arity1<C, UnsignedIntType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new UnsignedIntType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link LongType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link LongType}s.
+//	 * @implNote op names='convert.int64, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<LongType> typeToLong(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, LongType, RandomAccessibleInterval<LongType>> creator,
+//			@OpDependency(
+//				name = "convert.int64") Computers.Arity1<C, LongType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new LongType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link UnsignedLongType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link UnsignedLongType}s.
+//	 * @implNote op names='convert.uint64, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<UnsignedLongType> typeToUnsignedLong(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, UnsignedLongType, RandomAccessibleInterval<UnsignedLongType>> creator,
+//			@OpDependency(
+//				name = "convert.uint64") Computers.Arity1<C, UnsignedLongType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new UnsignedLongType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link Unsigned128BitType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link Unsigned128BitType}s.
+//	 * @implNote op names='convert.uint128, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<Unsigned128BitType> typeToUnsigned128Bit(
+//			@OpDependency(
+//				name = "create.img") BiFunction<Dimensions, Unsigned128BitType, RandomAccessibleInterval<Unsigned128BitType>> creator,
+//			@OpDependency(
+//				name = "convert.uint128") Computers.Arity1<C, Unsigned128BitType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new Unsigned128BitType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link FloatType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link FloatType}s.
+//	 * @implNote op names='convert.float32, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<FloatType> typeToFloat32(@OpDependency(
+//			name = "create.img") BiFunction<Dimensions, FloatType, RandomAccessibleInterval<FloatType>> creator,
+//			@OpDependency(
+//				name = "convert.float32") Computers.Arity1<C, FloatType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new FloatType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param creator a {@link BiFunction} to create the output image
+//	 * @param converter a {@link Computers.Arity1} to convert the type to a
+//	 *          {@link ComplexFloatType}
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link ComplexFloatType}s.
+//	 * @implNote op names='convert.cfloat32, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<ComplexFloatType> typeToComplexFloat32(
+//			@OpDependency(
+//				name = "create.img") BiFunction<Dimensions, ComplexFloatType, RandomAccessibleInterval<ComplexFloatType>> creator,
+//			@OpDependency(
+//				name = "convert.cfloat32") Computers.Arity1<C, ComplexFloatType> converter,
+//			final RAIC input)
+//	{
+//        var output = creator.apply(input,
+//			new ComplexFloatType());
+//		LoopBuilder.setImages(input, output).forEachPixel(converter);
+//		return output;
+//	}
+//
+//	/**
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link DoubleType}s.
+//	 * @implNote op names='convert.float64, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<DoubleType> typeToDoubleType(final RAIC input)
+//	{
+//		return Converters.convert(input, sampler -> new DoubleType(new DoubleAccess() {
+//
+//			@Override
+//			public double getValue(int index) {
+//				return sampler.get().getRealDouble();
+//			}
+//
+//			@Override
+//			public void setValue(int index, double value) {
+//				sampler.get().setReal(value);
+//				sampler.get().setImaginary(0);
+//			}
+//		}));
+//	}
+//
+//	/**
+//	 * @param input the input image
+//	 * @return an output image whose values are equivalent to {@code input}'s
+//	 *         values but whose element types are {@link ComplexDoubleType}s.
+//	 * @implNote op names='convert.cfloat64, engine.convert', type=Function
+//	 */
+//	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>>
+//		RandomAccessibleInterval<ComplexDoubleType> typeToComplexDouble32(
+//			final RAIC input)
+//	{
+//		return Converters.convert(input, sampler -> new ComplexDoubleType(new DoubleAccess() {
+//
+//			@Override
+//			public double getValue(int index) {
+//				if (index % 2 == 0) {
+//					return sampler.get().getRealDouble();
+//				} else {
+//					return sampler.get().getImaginaryDouble();
+//				}
+//			}
+//
+//			@Override
+//			public void setValue(int index, double value) {
+//				if (index % 2 == 0) {
+//					sampler.get().setReal(value);
+//				} else {
+//					sampler.get().setImaginary(value);
+//				}
+//			}
+//		}));
+//	}
 
 }

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/RAIWrappers.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/RAIWrappers.java
@@ -1,0 +1,356 @@
+package org.scijava.ops.image.convert;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.basictypeaccess.*;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.*;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+
+/**
+ * Wrapper Ops for {@link RandomAccessibleInterval}s of {@link ComplexType}s.
+ * TODO: Add more types
+ *
+ * @author Gabriel Selzer
+ */
+public class RAIWrappers {
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<BitType> toBitType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new BitType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				// TODO: Check correctness
+				return sampler.get().getRealDouble() != 0 ? -1L : 0L;
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value != 0 ? 1 : 0);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ByteType> toByteType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new ByteType(new ByteAccess() {
+
+			@Override
+			public byte getValue(int index) {
+				// TODO: Check correctness
+				return (byte) sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, byte value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedByteType> toUnsignedByteType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new UnsignedByteType(new ByteAccess() {
+
+			@Override
+			public byte getValue(int index) {
+				// TODO: Check correctness
+				return UnsignedByteType.getCodedSignedByte((int) sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, byte value) {
+				sampler.get().setReal(UnsignedByteType.getUnsignedByte(value));
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ShortType> toShortType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new ShortType(new ShortAccess() {
+
+			@Override
+			public short getValue(int index) {
+				return (short) sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, short value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedShortType> toUnsignedShortType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new UnsignedShortType(new ShortAccess() {
+
+			@Override
+			public short getValue(int index) {
+				// TODO: Check correctness
+				return UnsignedShortType.getCodedSignedShort((int) sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, short value) {
+				sampler.get().setReal(UnsignedShortType.getUnsignedShort(value));
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<IntType> toIntType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new IntType(new IntAccess() {
+
+			@Override
+			public int getValue(int index) {
+				return (int) sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, int value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedIntType> toUnsignedIntType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new UnsignedIntType(new IntAccess() {
+
+			@Override
+			public int getValue(int index) {
+				return UnsignedIntType.getCodedSignedInt((long) sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, int value) {
+				sampler.get().setReal(UnsignedIntType.getUnsignedInt(value));
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<LongType> toLongType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new LongType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				return (long) sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedLongType> toUnsignedLong(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new UnsignedLongType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				return (long) sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<FloatType> toFloatType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new FloatType(new FloatAccess() {
+
+			@Override
+			public float getValue(int index) {
+				return sampler.get().getRealFloat();
+			}
+
+			@Override
+			public void setValue(int index, float value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link FloatType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ComplexFloatType> toComplexFloatType(
+		final RAIC input)
+	{
+		return Converters.convert(input, sampler -> new ComplexFloatType(new FloatAccess() {
+
+			@Override
+			public float getValue(int index) {
+				if (index % 2 == 0) {
+					return sampler.get().getRealFloat();
+				}
+				else {
+					return sampler.get().getImaginaryFloat();
+				}
+			}
+
+			@Override
+			public void setValue(int index, float value) {
+				if (index % 2 == 0) {
+					sampler.get().setReal(value);
+				}
+				else {
+					sampler.get().setImaginary(value);
+				}
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link DoubleType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<DoubleType> toDoubleType(
+		final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new DoubleType(new DoubleAccess() {
+
+			@Override
+			public double getValue(int index) {
+				return sampler.get().getRealDouble();
+			}
+
+			@Override
+			public void setValue(int index, double value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link ComplexDoubleType}s.
+	 * @implNote op names='engine.convert', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ComplexDoubleType> toComplexDoubleType(
+		final RAIC input)
+	{
+		return Converters.convert(input, sampler -> new ComplexDoubleType(new DoubleAccess() {
+
+			@Override
+			public double getValue(int index) {
+				if (index % 2 == 0) {
+					return sampler.get().getRealDouble();
+				}
+				else {
+					return sampler.get().getImaginaryDouble();
+				}
+			}
+
+			@Override
+			public void setValue(int index, double value) {
+				if (index % 2 == 0) {
+					sampler.get().setReal(value);
+				}
+				else {
+					sampler.get().setImaginary(value);
+				}
+			}
+		}));
+	}
+}

--- a/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/RAIWrappers.java
+++ b/scijava-ops-image/src/main/java/org/scijava/ops/image/convert/RAIWrappers.java
@@ -1,3 +1,31 @@
+/*-
+ * #%L
+ * Image processing operations for SciJava Ops.
+ * %%
+ * Copyright (C) 2014 - 2025 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package org.scijava.ops.image.convert;
 
 import net.imglib2.RandomAccessibleInterval;
@@ -23,7 +51,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.bit', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<BitType> toBitType(
 		final RAIC input)
@@ -47,8 +75,56 @@ public class RAIWrappers {
 	/**
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link Unsigned2BitType}s.
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint2', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<Unsigned2BitType> toU2BitType(
+			final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new Unsigned2BitType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				return Types.uint2(sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link Unsigned4BitType}s.
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint4', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<Unsigned4BitType> toU4BitType(
+			final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new Unsigned4BitType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				return Types.uint4(sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.int8', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ByteType> toByteType(
 		final RAIC input)
@@ -73,7 +149,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint8', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedByteType> toUnsignedByteType(
 		final RAIC input)
@@ -97,8 +173,32 @@ public class RAIWrappers {
 	/**
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link Unsigned12BitType}s.
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint12', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<Unsigned12BitType> toU12BitType(
+			final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new Unsigned12BitType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				return Types.uint12(sampler.get().getRealDouble());
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.int16', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ShortType> toShortType(
 		final RAIC input)
@@ -122,7 +222,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint16', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedShortType> toUnsignedShortType(
 		final RAIC input)
@@ -148,7 +248,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.int32', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<IntType> toIntType(
 		final RAIC input)
@@ -172,7 +272,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint32', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedIntType> toUnsignedIntType(
 		final RAIC input)
@@ -196,7 +296,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.int64', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<LongType> toLongType(
 		final RAIC input)
@@ -220,7 +320,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint64', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<UnsignedLongType> toUnsignedLong(
 		final RAIC input)
@@ -243,8 +343,45 @@ public class RAIWrappers {
 	/**
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
+	 * 	values but whose element types are {@link Unsigned128BitType}s.
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint128', type=Function
+	 */
+	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<Unsigned128BitType> toU128BitType(
+			final RAIC input)
+	{
+		return net.imglib2.converter.Converters.convert(input, sampler -> new Unsigned128BitType(new LongAccess() {
+
+			@Override
+			public long getValue(int index) {
+				// This code is adapted from:
+				// net.imglib2.type.numeric.integer.Unsigned128BitType.setReal
+				double value = sampler.get().getRealDouble();
+				value = Math.floor( value + 0.5 );
+				final double base = Math.pow( 2, 64 );
+				double upper = Math.floor(value / base );
+				double lower = value - base * upper;
+				if (index % 2 == 0) { // lower long
+					return Types.int64(lower);
+				}
+				else { // upper long
+					return Types.int64(upper);
+				}
+			}
+
+			@Override
+			public void setValue(int index, long value) {
+				// FIXME
+				sampler.get().setReal(value);
+				sampler.get().setImaginary(0);
+			}
+		}));
+	}
+
+	/**
+	 * @param input the input image
+	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.float32', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<FloatType> toFloatType(
 		final RAIC input)
@@ -268,7 +405,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link FloatType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.cfloat32', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ComplexFloatType> toComplexFloatType(
 		final RAIC input)
@@ -301,7 +438,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link DoubleType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.float64', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<DoubleType> toDoubleType(
 		final RAIC input)
@@ -325,7 +462,7 @@ public class RAIWrappers {
 	 * @param input the input image
 	 * @return an output image whose values are equivalent to {@code input}'s
 	 * 	values but whose element types are {@link ComplexDoubleType}s.
-	 * @implNote op names='engine.convert', type=Function
+	 * @implNote op names='engine.convert, engine.wrap, convert.uint64', type=Function
 	 */
 	public static <C extends ComplexType<C>, RAIC extends RandomAccessibleInterval<C>> RandomAccessibleInterval<ComplexDoubleType> toComplexDoubleType(
 		final RAIC input)

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/ConvertImagesCorrectnessTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/ConvertImagesCorrectnessTest.java
@@ -29,19 +29,56 @@
 package org.scijava.ops.image.convert;
 
 import net.imglib2.img.array.ArrayImgs;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.scijava.common3.MersenneTwisterFast;
 
 public class ConvertImagesCorrectnessTest {
 
 	@Test
-	public void realTypeToComplexTypeTest() {
+	public void realTypeToComplexDoubleTypeTest() {
 		MersenneTwisterFast mt = new MersenneTwisterFast(0xdeadbeefL);
 		int width = 10, height = 10;
-		var backing = ArrayImgs.doubles(width, height);
+		var backing = ArrayImgs.bytes(width, height);
+		var converted = RAIWrappers.toComplexDoubleType(backing);
+
 		var cursor = backing.cursor();
+		var ra = converted.randomAccess();
+		double inc = 3.2;
+		byte max = (byte) (Byte.MAX_VALUE - (byte) Math.ceil(inc));
 		while(cursor.hasNext()) {
-			cursor.next().setReal(mt.nextDouble());
+			cursor.next();
+			ra.setPosition(cursor);
+			byte b = mt.nextByte();
+			if (b > max) b = max;
+			cursor.get().set(b);
+			Assertions.assertEquals(b, ra.get().getRealDouble());
+			ra.get().set(b + inc, inc);
+			Assertions.assertEquals(b + (byte) inc, cursor.get().get());
+			Assertions.assertEquals(0, cursor.get().getImaginaryDouble());
+		}
+	}
+
+	@Test
+	public void complexTypeToComplexDoubleTypeTest() {
+		MersenneTwisterFast mt = new MersenneTwisterFast(0xdeadbeefL);
+		int width = 10, height = 10;
+		var backing = ArrayImgs.complexFloats(width, height);
+		var converted = RAIWrappers.toComplexDoubleType(backing);
+
+		var cursor = backing.cursor();
+		var ra = converted.randomAccess();
+		while(cursor.hasNext()) {
+			cursor.next();
+			ra.setPosition(cursor);
+			var r = mt.nextFloat();
+			var i = mt.nextFloat();
+			cursor.get().set(r, i);
+			Assertions.assertEquals(r, ra.get().getRealDouble(), 1e-6);
+			Assertions.assertEquals(i, ra.get().getImaginaryDouble(), 1e-6);
+			ra.get().set(r + r, i + i);
+			Assertions.assertEquals(r + r, cursor.get().getRealFloat(), 1e-6);
+			Assertions.assertEquals(i + i, cursor.get().getImaginaryFloat(), 1e-6);
 		}
 	}
 

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/ConvertImagesCorrectnessTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/ConvertImagesCorrectnessTest.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * Image processing operations for SciJava Ops.
+ * %%
+ * Copyright (C) 2014 - 2025 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.scijava.ops.image.convert;
+
+import net.imglib2.img.array.ArrayImgs;
+import org.junit.jupiter.api.Test;
+import org.scijava.common3.MersenneTwisterFast;
+
+public class ConvertImagesCorrectnessTest {
+
+	@Test
+	public void realTypeToComplexTypeTest() {
+		MersenneTwisterFast mt = new MersenneTwisterFast(0xdeadbeefL);
+		int width = 10, height = 10;
+		var backing = ArrayImgs.doubles(width, height);
+		var cursor = backing.cursor();
+		while(cursor.hasNext()) {
+			cursor.next().setReal(mt.nextDouble());
+		}
+	}
+
+
+
+}

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/RAIConvertersTest.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/RAIConvertersTest.java
@@ -37,8 +37,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.logic.BitType;
-import net.imglib2.type.numeric.complex.ComplexDoubleType;
-import net.imglib2.type.numeric.complex.ComplexFloatType;
 import net.imglib2.type.numeric.integer.*;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -52,7 +50,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.BitType', type='Computer'
 	 */
-	public static void computeBitType(RandomAccessibleInterval<BitType> out) {
+	public static void computeBitType(
+	    RandomAccessibleInterval<BitType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -70,7 +70,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.Unsigned2BitType', type='Computer'
 	 */
-	public static void computeUnsigned2BitType(RandomAccessibleInterval<Unsigned2BitType> out) {
+	public static void computeUnsigned2BitType(
+	    RandomAccessibleInterval<Unsigned2BitType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -88,7 +90,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.Unsigned4BitType', type='Computer'
 	 */
-	public static void computeUnsigned4BitType(RandomAccessibleInterval<Unsigned4BitType> out) {
+	public static void computeUnsigned4BitType(
+	    RandomAccessibleInterval<Unsigned4BitType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -106,7 +110,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.UnsignedByteType', type='Computer'
 	 */
-	public static void computeUnsignedByteType(RandomAccessibleInterval<UnsignedByteType> out) {
+	public static void computeUnsignedByteType(
+	    RandomAccessibleInterval<UnsignedByteType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -124,7 +130,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.ByteType', type='Computer'
 	 */
-	public static void computeByteType(RandomAccessibleInterval<ByteType> out) {
+	public static void computeByteType(
+	    RandomAccessibleInterval<ByteType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -142,7 +150,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.UnsignedShortType', type='Computer'
 	 */
-	public static void computeUnsignedShortType(RandomAccessibleInterval<UnsignedShortType> out) {
+	public static void computeUnsignedShortType(
+	    RandomAccessibleInterval<UnsignedShortType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -160,7 +170,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.ShortType', type='Computer'
 	 */
-	public static void computeShortType(RandomAccessibleInterval<ShortType> out) {
+	public static void computeShortType(
+	    RandomAccessibleInterval<ShortType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -178,7 +190,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.Unsigned12BitType', type='Computer'
 	 */
-	public static void computeUnsigned12BitType(RandomAccessibleInterval<Unsigned12BitType> out) {
+	public static void computeUnsigned12BitType(
+	    RandomAccessibleInterval<Unsigned12BitType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -196,7 +210,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.UnsignedIntType', type='Computer'
 	 */
-	public static void computeUnsignedIntType(RandomAccessibleInterval<UnsignedIntType> out) {
+	public static void computeUnsignedIntType(
+	    RandomAccessibleInterval<UnsignedIntType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -214,7 +230,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.IntType', type='Computer'
 	 */
-	public static void computeIntType(RandomAccessibleInterval<IntType> out) {
+	public static void computeIntType(
+	    RandomAccessibleInterval<IntType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -232,7 +250,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.UnsignedLongType', type='Computer'
 	 */
-	public static void computeUnsignedLongType(RandomAccessibleInterval<UnsignedLongType> out) {
+	public static void computeUnsignedLongType(
+	    RandomAccessibleInterval<UnsignedLongType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -250,7 +270,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.LongType', type='Computer'
 	 */
-	public static void computeLongType(RandomAccessibleInterval<LongType> out) {
+	public static void computeLongType(
+	    RandomAccessibleInterval<LongType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -268,7 +290,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.Unsigned128BitType', type='Computer'
 	 */
-	public static void computeUnsigned128BitType(RandomAccessibleInterval<Unsigned128BitType> out) {
+	public static void computeUnsigned128BitType(
+	    RandomAccessibleInterval<Unsigned128BitType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -286,7 +310,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.FloatType', type='Computer'
 	 */
-	public static void computeFloatType(RandomAccessibleInterval<FloatType> out) {
+	public static void computeFloatType(
+	    RandomAccessibleInterval<FloatType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
@@ -304,7 +330,9 @@ public class RAIConvertersTest extends AbstractOpTest {
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.DoubleType', type='Computer'
 	 */
-	public static void computeDoubleType(RandomAccessibleInterval<DoubleType> out) {
+	public static void computeDoubleType(
+	    RandomAccessibleInterval<DoubleType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/TestConvertImages.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/TestConvertImages.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.math.BigInteger;
 
 import net.imglib2.FinalDimensions;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.IterableInterval;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -56,10 +56,8 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.view.Views;
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.image.AbstractOpTest;
-import org.scijava.types.Nil;
 
 /**
  * Tests the {@link ConvertComplexTypes} ops.
@@ -76,6 +74,7 @@ public class TestConvertImages extends AbstractOpTest{
 	private final BigInteger n128 = new BigInteger("-482301498A285BFD0982EE7DE02398BC9080459284CCDE90E9F0D00C043981210481AAADEF2", 16);
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToBit() {
 
@@ -92,7 +91,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -103,6 +102,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToBit() {
 
@@ -119,7 +119,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -130,6 +130,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToBit() {
 
@@ -146,7 +147,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -157,6 +158,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToBit() {
 
@@ -173,7 +175,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -181,7 +183,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -192,6 +194,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToBit() {
 
@@ -208,7 +211,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -219,6 +222,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToBit() {
 
@@ -235,7 +239,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -246,6 +250,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToBit() {
 
@@ -262,7 +267,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -270,7 +275,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -281,6 +286,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToBit() {
 
@@ -297,7 +303,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -308,6 +314,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToBit() {
 
@@ -324,7 +331,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -332,7 +339,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -343,6 +350,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToBit() {
 
@@ -359,7 +367,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -370,6 +378,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToBit() {
 
@@ -386,7 +395,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -394,7 +403,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -405,6 +414,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToBit() {
 
@@ -421,7 +431,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -429,7 +439,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -440,6 +450,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToBit() {
 
@@ -456,7 +467,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -464,7 +475,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -475,6 +486,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToBit() {
 
@@ -491,7 +503,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -499,7 +511,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -510,6 +522,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToBit() {
 
@@ -526,7 +539,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -534,7 +547,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -545,6 +558,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToBit() {
 
@@ -561,7 +575,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -569,7 +583,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -577,7 +591,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -588,6 +602,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToBit}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToBit() {
 
@@ -604,7 +619,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -612,7 +627,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.bit(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.bit").input(img).apply();
 		cursor = ((IterableInterval<BitType>) converted).cursor();
@@ -623,6 +638,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint2() {
 
@@ -639,7 +655,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -650,6 +666,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint2() {
 
@@ -666,7 +683,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -677,6 +694,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint2() {
 
@@ -693,7 +711,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -704,6 +722,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint2() {
 
@@ -720,7 +739,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -728,7 +747,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -739,6 +758,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint2() {
 
@@ -755,7 +775,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -766,6 +786,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint2() {
 
@@ -782,7 +803,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -793,6 +814,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint2() {
 
@@ -809,7 +831,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -817,7 +839,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -828,6 +850,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint2() {
 
@@ -844,7 +867,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -855,6 +878,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint2() {
 
@@ -871,7 +895,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -879,7 +903,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -890,6 +914,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint2() {
 
@@ -906,7 +931,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -917,6 +942,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint2() {
 
@@ -933,7 +959,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -941,7 +967,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -952,6 +978,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint2() {
 
@@ -968,7 +995,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -976,7 +1003,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -987,6 +1014,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint2() {
 
@@ -1003,7 +1031,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1011,7 +1039,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1022,6 +1050,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint2() {
 
@@ -1038,7 +1067,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1046,7 +1075,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1057,6 +1086,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint2() {
 
@@ -1073,7 +1103,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1081,7 +1111,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1092,6 +1122,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint2() {
 
@@ -1108,7 +1139,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1116,7 +1147,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1124,7 +1155,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1135,6 +1166,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint2}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint2() {
 
@@ -1151,7 +1183,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1159,7 +1191,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint2(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint2").input(img).apply();
 		cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
@@ -1170,6 +1202,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint4() {
 
@@ -1186,7 +1219,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1197,6 +1230,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint4() {
 
@@ -1213,7 +1247,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1224,6 +1258,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint4() {
 
@@ -1240,7 +1275,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1251,6 +1286,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint4() {
 
@@ -1267,7 +1303,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1275,7 +1311,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1286,6 +1322,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint4() {
 
@@ -1302,7 +1339,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1313,6 +1350,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint4() {
 
@@ -1329,7 +1367,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1340,6 +1378,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint4() {
 
@@ -1356,7 +1395,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1364,7 +1403,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1375,6 +1414,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint4() {
 
@@ -1391,7 +1431,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1402,6 +1442,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint4() {
 
@@ -1418,7 +1459,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1426,7 +1467,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1437,6 +1478,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint4() {
 
@@ -1453,7 +1495,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1464,6 +1506,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint4() {
 
@@ -1480,7 +1523,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1488,7 +1531,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1499,6 +1542,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint4() {
 
@@ -1515,7 +1559,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1523,7 +1567,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1534,6 +1578,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint4() {
 
@@ -1550,7 +1595,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1558,7 +1603,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1569,6 +1614,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint4() {
 
@@ -1585,7 +1631,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1593,7 +1639,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1604,6 +1650,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint4() {
 
@@ -1620,7 +1667,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1628,7 +1675,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1639,6 +1686,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint4() {
 
@@ -1655,7 +1703,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1663,7 +1711,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1671,7 +1719,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1682,6 +1730,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint4}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint4() {
 
@@ -1698,7 +1747,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1706,7 +1755,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint4(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint4").input(img).apply();
 		cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
@@ -1717,6 +1766,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToInt8() {
 
@@ -1733,7 +1783,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1744,6 +1794,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToInt8() {
 
@@ -1760,7 +1811,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1771,6 +1822,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToInt8() {
 
@@ -1787,7 +1839,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1798,6 +1850,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToInt8() {
 
@@ -1814,7 +1867,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1822,7 +1875,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1833,6 +1886,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToInt8() {
 
@@ -1849,7 +1903,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1860,6 +1914,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToInt8() {
 
@@ -1876,7 +1931,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1887,6 +1942,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToInt8() {
 
@@ -1903,7 +1959,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1911,7 +1967,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1922,6 +1978,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToInt8() {
 
@@ -1938,7 +1995,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1949,6 +2006,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToInt8() {
 
@@ -1965,7 +2023,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1973,7 +2031,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -1984,6 +2042,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToInt8() {
 
@@ -2000,7 +2059,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2011,6 +2070,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToInt8() {
 
@@ -2027,7 +2087,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2035,7 +2095,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2046,6 +2106,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToInt8() {
 
@@ -2062,7 +2123,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2070,7 +2131,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2081,6 +2142,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToInt8() {
 
@@ -2097,7 +2159,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2105,7 +2167,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2116,6 +2178,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToInt8() {
 
@@ -2132,7 +2195,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2140,7 +2203,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2151,6 +2214,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToInt8() {
 
@@ -2167,7 +2231,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2175,7 +2239,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2186,6 +2250,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToInt8() {
 
@@ -2202,7 +2267,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2210,7 +2275,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2218,7 +2283,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2229,6 +2294,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToInt8() {
 
@@ -2245,7 +2311,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2253,7 +2319,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int8(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int8").input(img).apply();
 		cursor = ((IterableInterval<ByteType>) converted).cursor();
@@ -2264,6 +2330,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint8() {
 
@@ -2280,7 +2347,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2291,6 +2358,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint8() {
 
@@ -2307,7 +2375,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2318,6 +2386,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint8() {
 
@@ -2334,7 +2403,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2345,6 +2414,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint8() {
 
@@ -2361,7 +2431,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2369,7 +2439,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2380,6 +2450,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint8() {
 
@@ -2396,7 +2467,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2407,6 +2478,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint8() {
 
@@ -2423,7 +2495,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2434,6 +2506,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint8() {
 
@@ -2450,7 +2523,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2458,7 +2531,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2469,6 +2542,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint8() {
 
@@ -2485,7 +2559,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2496,6 +2570,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint8() {
 
@@ -2512,7 +2587,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2520,7 +2595,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2531,6 +2606,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint8() {
 
@@ -2547,7 +2623,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2558,6 +2634,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint8() {
 
@@ -2574,7 +2651,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2582,7 +2659,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2593,6 +2670,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint8() {
 
@@ -2609,7 +2687,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2617,7 +2695,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2628,6 +2706,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint8() {
 
@@ -2644,7 +2723,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2652,7 +2731,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2663,6 +2742,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint8() {
 
@@ -2679,7 +2759,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2687,7 +2767,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2698,6 +2778,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint8() {
 
@@ -2714,7 +2795,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2722,7 +2803,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2733,6 +2814,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint8() {
 
@@ -2749,7 +2831,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2757,7 +2839,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2765,7 +2847,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2776,6 +2858,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint8}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint8() {
 
@@ -2792,7 +2875,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2800,7 +2883,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint8(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint8").input(img).apply();
 		cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
@@ -2811,6 +2894,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint12() {
 
@@ -2827,7 +2911,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2838,6 +2922,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint12() {
 
@@ -2854,7 +2939,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2865,6 +2950,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint12() {
 
@@ -2881,7 +2967,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2892,6 +2978,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint12() {
 
@@ -2908,7 +2995,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2916,7 +3003,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2927,6 +3014,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint12() {
 
@@ -2943,7 +3031,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2954,6 +3042,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint12() {
 
@@ -2970,7 +3059,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -2981,6 +3070,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint12() {
 
@@ -2997,7 +3087,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3005,7 +3095,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3016,6 +3106,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint12() {
 
@@ -3032,7 +3123,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3043,6 +3134,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint12() {
 
@@ -3059,7 +3151,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3067,7 +3159,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3078,6 +3170,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint12() {
 
@@ -3094,7 +3187,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3105,6 +3198,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint12() {
 
@@ -3121,7 +3215,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3129,7 +3223,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3140,6 +3234,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint12() {
 
@@ -3156,7 +3251,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3164,7 +3259,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3175,6 +3270,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint12() {
 
@@ -3191,7 +3287,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3199,7 +3295,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3210,6 +3306,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint12() {
 
@@ -3226,7 +3323,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3234,7 +3331,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3245,6 +3342,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint12() {
 
@@ -3261,7 +3359,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3269,7 +3367,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3280,6 +3378,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint12() {
 
@@ -3296,7 +3395,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3304,7 +3403,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3312,7 +3411,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3323,6 +3422,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint12}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint12() {
 
@@ -3339,7 +3439,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3347,7 +3447,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint12(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint12").input(img).apply();
 		cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
@@ -3358,6 +3458,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToInt16() {
 
@@ -3374,7 +3475,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3385,6 +3486,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToInt16() {
 
@@ -3401,7 +3503,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3412,6 +3514,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToInt16() {
 
@@ -3428,7 +3531,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3439,6 +3542,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToInt16() {
 
@@ -3455,7 +3559,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3463,7 +3567,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3474,6 +3578,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToInt16() {
 
@@ -3490,7 +3595,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3501,6 +3606,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToInt16() {
 
@@ -3517,7 +3623,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3528,6 +3634,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToInt16() {
 
@@ -3544,7 +3651,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3552,7 +3659,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3563,6 +3670,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToInt16() {
 
@@ -3579,7 +3687,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3590,6 +3698,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToInt16() {
 
@@ -3606,7 +3715,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3614,7 +3723,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3625,6 +3734,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToInt16() {
 
@@ -3641,7 +3751,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3652,6 +3762,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToInt16() {
 
@@ -3668,7 +3779,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3676,7 +3787,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3687,6 +3798,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToInt16() {
 
@@ -3703,7 +3815,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3711,7 +3823,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3722,6 +3834,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToInt16() {
 
@@ -3738,7 +3851,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3746,7 +3859,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3757,6 +3870,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToInt16() {
 
@@ -3773,7 +3887,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3781,7 +3895,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3792,6 +3906,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToInt16() {
 
@@ -3808,7 +3923,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3816,7 +3931,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3827,6 +3942,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToInt16() {
 
@@ -3843,7 +3959,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3851,7 +3967,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3859,7 +3975,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3870,6 +3986,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToInt16() {
 
@@ -3886,7 +4003,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3894,7 +4011,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int16(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int16").input(img).apply();
 		cursor = ((IterableInterval<ShortType>) converted).cursor();
@@ -3905,6 +4022,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint16() {
 
@@ -3921,7 +4039,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -3932,6 +4050,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint16() {
 
@@ -3948,7 +4067,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -3959,6 +4078,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint16() {
 
@@ -3975,7 +4095,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -3986,6 +4106,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint16() {
 
@@ -4002,7 +4123,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4010,7 +4131,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4021,6 +4142,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint16() {
 
@@ -4037,7 +4159,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4048,6 +4170,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint16() {
 
@@ -4064,7 +4187,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4075,6 +4198,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint16() {
 
@@ -4091,7 +4215,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4099,7 +4223,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4110,6 +4234,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint16() {
 
@@ -4126,7 +4251,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4137,6 +4262,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint16() {
 
@@ -4153,7 +4279,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4161,7 +4287,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4172,6 +4298,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint16() {
 
@@ -4188,7 +4315,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4199,6 +4326,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint16() {
 
@@ -4215,7 +4343,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4223,7 +4351,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4234,6 +4362,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint16() {
 
@@ -4250,7 +4379,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4258,7 +4387,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4269,6 +4398,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint16() {
 
@@ -4285,7 +4415,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4293,7 +4423,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4304,6 +4434,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint16() {
 
@@ -4320,7 +4451,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4328,7 +4459,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4339,6 +4470,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint16() {
 
@@ -4355,7 +4487,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4363,7 +4495,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4374,6 +4506,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint16() {
 
@@ -4390,7 +4523,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4398,7 +4531,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4406,7 +4539,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4417,6 +4550,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint16}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint16() {
 
@@ -4433,7 +4567,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4441,7 +4575,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint16(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint16").input(img).apply();
 		cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
@@ -4452,6 +4586,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToInt32() {
 
@@ -4468,7 +4603,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4479,6 +4614,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToInt32() {
 
@@ -4495,7 +4631,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4506,6 +4642,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToInt32() {
 
@@ -4522,7 +4659,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4533,6 +4670,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToInt32() {
 
@@ -4549,7 +4687,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4557,7 +4695,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4568,6 +4706,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToInt32() {
 
@@ -4584,7 +4723,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4595,6 +4734,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToInt32() {
 
@@ -4611,7 +4751,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4622,6 +4762,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToInt32() {
 
@@ -4638,7 +4779,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4646,7 +4787,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4657,6 +4798,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToInt32() {
 
@@ -4673,7 +4815,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4684,6 +4826,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToInt32() {
 
@@ -4700,7 +4843,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4708,7 +4851,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4719,6 +4862,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToInt32() {
 
@@ -4735,7 +4879,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4746,6 +4890,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToInt32() {
 
@@ -4762,7 +4907,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4770,7 +4915,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4781,6 +4926,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToInt32() {
 
@@ -4797,7 +4943,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4805,7 +4951,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4816,6 +4962,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToInt32() {
 
@@ -4832,7 +4979,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4840,7 +4987,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4851,6 +4998,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToInt32() {
 
@@ -4867,7 +5015,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4875,7 +5023,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4886,6 +5034,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToInt32() {
 
@@ -4902,7 +5051,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4910,7 +5059,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4921,6 +5070,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToInt32() {
 
@@ -4937,7 +5087,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4945,7 +5095,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4953,7 +5103,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4964,6 +5114,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToInt32() {
 
@@ -4980,7 +5131,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4988,7 +5139,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int32(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int32").input(img).apply();
 		cursor = ((IterableInterval<IntType>) converted).cursor();
@@ -4999,6 +5150,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint32() {
 
@@ -5015,7 +5167,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5026,6 +5178,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint32() {
 
@@ -5042,7 +5195,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5053,6 +5206,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint32() {
 
@@ -5069,7 +5223,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5080,6 +5234,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint32() {
 
@@ -5096,7 +5251,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5104,7 +5259,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5115,6 +5270,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint32() {
 
@@ -5131,7 +5287,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5142,6 +5298,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint32() {
 
@@ -5158,7 +5315,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5169,6 +5326,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint32() {
 
@@ -5185,7 +5343,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5193,7 +5351,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5204,6 +5362,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint32() {
 
@@ -5220,7 +5379,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5231,6 +5390,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint32() {
 
@@ -5247,7 +5407,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5255,7 +5415,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5266,6 +5426,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint32() {
 
@@ -5282,7 +5443,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5293,6 +5454,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint32() {
 
@@ -5309,7 +5471,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5317,7 +5479,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5328,6 +5490,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint32() {
 
@@ -5344,7 +5507,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5352,7 +5515,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5363,6 +5526,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint32() {
 
@@ -5379,7 +5543,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5387,7 +5551,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5398,6 +5562,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint32() {
 
@@ -5414,7 +5579,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5422,7 +5587,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5433,6 +5598,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint32() {
 
@@ -5449,7 +5615,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5457,7 +5623,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5468,6 +5634,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint32() {
 
@@ -5484,7 +5651,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5492,7 +5659,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5500,7 +5667,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5511,6 +5678,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint32}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint32() {
 
@@ -5527,7 +5695,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5535,7 +5703,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint32(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint32").input(img).apply();
 		cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
@@ -5546,6 +5714,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToInt64() {
 
@@ -5562,7 +5731,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5573,6 +5742,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToInt64() {
 
@@ -5589,7 +5759,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5600,6 +5770,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToInt64() {
 
@@ -5616,7 +5787,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5627,6 +5798,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToInt64() {
 
@@ -5643,7 +5815,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5651,7 +5823,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5662,6 +5834,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToInt64() {
 
@@ -5678,7 +5851,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5689,6 +5862,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToInt64() {
 
@@ -5705,7 +5879,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5716,6 +5890,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToInt64() {
 
@@ -5732,7 +5907,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5740,7 +5915,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5751,6 +5926,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToInt64() {
 
@@ -5767,7 +5943,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5778,6 +5954,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToInt64() {
 
@@ -5794,7 +5971,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5802,7 +5979,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5813,6 +5990,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToInt64() {
 
@@ -5829,7 +6007,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5840,6 +6018,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToInt64() {
 
@@ -5856,7 +6035,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5864,7 +6043,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5875,6 +6054,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToInt64() {
 
@@ -5891,7 +6071,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5899,7 +6079,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5910,6 +6090,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToInt64() {
 
@@ -5926,7 +6107,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5934,7 +6115,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5945,6 +6126,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToInt64() {
 
@@ -5961,7 +6143,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5969,7 +6151,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -5980,6 +6162,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToInt64() {
 
@@ -5996,7 +6179,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6004,7 +6187,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6015,6 +6198,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToInt64() {
 
@@ -6031,7 +6215,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6039,7 +6223,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6047,7 +6231,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6058,6 +6242,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToInt64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToInt64() {
 
@@ -6074,7 +6259,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6082,7 +6267,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.int64(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.int64").input(img).apply();
 		cursor = ((IterableInterval<LongType>) converted).cursor();
@@ -6093,6 +6278,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint64() {
 
@@ -6109,7 +6295,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(1), cursor.next().getBigInteger());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6120,6 +6306,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint64() {
 
@@ -6136,7 +6323,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(2), cursor.next().getBigInteger());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6147,6 +6334,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint64() {
 
@@ -6163,7 +6351,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(15), cursor.next().getBigInteger());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6174,6 +6362,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint64() {
 
@@ -6190,7 +6379,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64((byte) 8), cursor.next().getBigInteger());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6198,7 +6387,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64((byte) 0), cursor.next().getBigInteger());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6209,6 +6398,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint64() {
 
@@ -6225,7 +6415,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(100), cursor.next().getBigInteger());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6236,6 +6426,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint64() {
 
@@ -6252,7 +6443,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(212L), cursor.next().getBigInteger());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6263,6 +6454,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint64() {
 
@@ -6279,7 +6471,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64((short) 52), cursor.next().getBigInteger());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6287,7 +6479,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64((short) 0), cursor.next().getBigInteger());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6298,6 +6490,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint64() {
 
@@ -6314,7 +6507,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(480), cursor.next().getBigInteger());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6325,6 +6518,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint64() {
 
@@ -6341,7 +6535,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(301), cursor.next().getBigInteger());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6349,7 +6543,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0), cursor.next().getBigInteger());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6360,6 +6554,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint64() {
 
@@ -6376,7 +6571,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(20L), cursor.next().getBigInteger());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6387,6 +6582,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint64() {
 
@@ -6403,7 +6599,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(891L), cursor.next().getBigInteger());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6411,7 +6607,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0L), cursor.next().getBigInteger());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6422,6 +6618,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint64() {
 
@@ -6438,7 +6635,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(1049L), cursor.next().getBigInteger());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6446,7 +6643,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0L), cursor.next().getBigInteger());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6457,6 +6654,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint64() {
 
@@ -6473,7 +6671,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(beef), cursor.next().getBigInteger());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6481,7 +6679,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(biZero), cursor.next().getBigInteger());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6492,6 +6690,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint64() {
 
@@ -6508,7 +6707,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(123453.125f), cursor.next().getBigInteger());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6516,7 +6715,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0f), cursor.next().getBigInteger());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6527,6 +6726,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint64() {
 
@@ -6543,7 +6743,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(5839.25f), cursor.next().getBigInteger());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6551,7 +6751,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0f), cursor.next().getBigInteger());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6562,6 +6762,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint64() {
 
@@ -6578,7 +6779,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(4098d), cursor.next().getBigInteger());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6586,7 +6787,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0d), cursor.next().getBigInteger());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6594,7 +6795,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(-10948.015625d), cursor.next().getBigInteger());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6605,6 +6806,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint64}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint64() {
 
@@ -6621,7 +6823,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(9087d), cursor.next().getBigInteger());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6629,7 +6831,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint64(0d), cursor.next().getBigInteger());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint64").input(img).apply();
 		cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
@@ -6640,6 +6842,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToUint128() {
 
@@ -6656,7 +6859,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(1), cursor.next().get());
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6667,6 +6870,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToUint128() {
 
@@ -6683,7 +6887,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(2), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6694,6 +6898,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToUint128() {
 
@@ -6710,7 +6915,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(15), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6721,6 +6926,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToUint128() {
 
@@ -6737,7 +6943,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128((byte) 8), cursor.next().get());
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6745,7 +6951,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128((byte) 0), cursor.next().get());
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6756,6 +6962,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToUint128() {
 
@@ -6772,7 +6979,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(100), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6783,6 +6990,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToUint128() {
 
@@ -6799,7 +7007,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(212L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6810,6 +7018,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToUint128() {
 
@@ -6826,7 +7035,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128((short) 52), cursor.next().get());
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6834,7 +7043,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128((short) 0), cursor.next().get());
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6845,6 +7054,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToUint128() {
 
@@ -6861,7 +7071,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(480), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6872,6 +7082,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToUint128() {
 
@@ -6888,7 +7099,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(301), cursor.next().get());
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6896,7 +7107,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0), cursor.next().get());
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6907,6 +7118,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToUint128() {
 
@@ -6923,7 +7135,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(20L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6934,6 +7146,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToUint128() {
 
@@ -6950,7 +7163,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(891L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6958,7 +7171,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0L), cursor.next().get());
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6969,6 +7182,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToUint128() {
 
@@ -6985,7 +7199,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(1049L), cursor.next().get());
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -6993,7 +7207,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0L), cursor.next().get());
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7004,6 +7218,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToUint128() {
 
@@ -7020,7 +7235,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(beef), cursor.next().get());
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7028,7 +7243,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(biZero), cursor.next().get());
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7039,6 +7254,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToUint128() {
 
@@ -7055,7 +7271,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(123453.125f), cursor.next().get());
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7063,7 +7279,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0f), cursor.next().get());
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7074,6 +7290,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToUint128() {
 
@@ -7090,7 +7307,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(5839.25f), cursor.next().get());
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7098,7 +7315,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0f), cursor.next().get());
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7109,6 +7326,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToUint128() {
 
@@ -7125,7 +7343,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(4098d), cursor.next().get());
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7133,7 +7351,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0d), cursor.next().get());
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7141,7 +7359,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(-10948.015625d), cursor.next().get());
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7152,6 +7370,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToUint128() {
 
@@ -7168,7 +7387,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(9087d), cursor.next().get());
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7176,7 +7395,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.uint128(0d), cursor.next().get());
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.uint128").input(img).apply();
 		cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
@@ -7187,6 +7406,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToFloat32() {
 
@@ -7203,7 +7423,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(1), cursor.next().get(), 0);
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7214,6 +7434,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToFloat32() {
 
@@ -7230,7 +7451,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(2), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7241,6 +7462,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToFloat32() {
 
@@ -7257,7 +7479,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(15), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7268,6 +7490,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToFloat32() {
 
@@ -7284,7 +7507,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((byte) 8), cursor.next().get(), 0);
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7292,7 +7515,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((byte) 0), cursor.next().get(), 0);
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7303,6 +7526,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToFloat32() {
 
@@ -7319,7 +7543,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(100), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7330,6 +7554,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToFloat32() {
 
@@ -7346,7 +7571,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(212L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7357,6 +7582,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToFloat32() {
 
@@ -7373,7 +7599,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((short) 52), cursor.next().get(), 0);
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7381,7 +7607,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((short) 0), cursor.next().get(), 0);
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7392,6 +7618,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToFloat32() {
 
@@ -7408,7 +7635,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(480), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7419,6 +7646,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToFloat32() {
 
@@ -7435,7 +7663,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(301), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7443,7 +7671,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().get(), 0);
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7454,6 +7682,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToFloat32() {
 
@@ -7470,7 +7699,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(20L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7481,6 +7710,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToFloat32() {
 
@@ -7497,7 +7727,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(891L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7505,7 +7735,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().get(), 0);
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7516,6 +7746,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToFloat32() {
 
@@ -7532,7 +7763,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(1049L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7540,7 +7771,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().get(), 0);
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7551,6 +7782,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToFloat32() {
 
@@ -7567,7 +7799,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(beef), cursor.next().get(), 0);
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7575,7 +7807,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(biZero), cursor.next().get(), 0);
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7586,6 +7818,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToFloat32() {
 
@@ -7602,7 +7835,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(123453.125f), cursor.next().get(), 0);
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7610,7 +7843,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0f), cursor.next().get(), 0);
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7621,6 +7854,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToFloat32() {
 
@@ -7637,7 +7871,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(5839.25f), cursor.next().get(), 0);
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7645,7 +7879,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0f), cursor.next().get(), 0);
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7656,6 +7890,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToFloat32() {
 
@@ -7672,7 +7907,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(4098d), cursor.next().get(), 0);
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7680,7 +7915,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().get(), 0);
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7688,7 +7923,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(-10948.015625d), cursor.next().get(), 0);
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7699,6 +7934,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToFloat32() {
 
@@ -7715,7 +7951,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(9087d), cursor.next().get(), 0);
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7723,7 +7959,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().get(), 0);
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float32").input(img).apply();
 		cursor = ((IterableInterval<FloatType>) converted).cursor();
@@ -7734,6 +7970,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToCfloat32() {
 
@@ -7751,7 +7988,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7763,6 +8000,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToCfloat32() {
 
@@ -7780,7 +8018,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7792,6 +8030,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToCfloat32() {
 
@@ -7809,7 +8048,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7821,6 +8060,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToCfloat32() {
 
@@ -7838,7 +8078,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((byte) 0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7847,7 +8087,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((byte) 0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7859,6 +8099,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToCfloat32() {
 
@@ -7876,7 +8117,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7888,6 +8129,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToCfloat32() {
 
@@ -7905,7 +8147,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7917,6 +8159,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToCfloat32() {
 
@@ -7934,7 +8177,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((short) 0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7943,7 +8186,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32((short) 0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7955,6 +8198,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToCfloat32() {
 
@@ -7972,7 +8216,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -7984,6 +8228,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToCfloat32() {
 
@@ -8001,7 +8246,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8010,7 +8255,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8022,6 +8267,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToCfloat32() {
 
@@ -8039,7 +8285,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8051,6 +8297,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToCfloat32() {
 
@@ -8068,7 +8315,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8077,7 +8324,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8089,6 +8336,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToCfloat32() {
 
@@ -8106,7 +8354,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8115,7 +8363,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0L), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8127,6 +8375,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToCfloat32() {
 
@@ -8144,7 +8393,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(biZero), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8153,7 +8402,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(biZero), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8165,6 +8414,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToCfloat32() {
 
@@ -8182,7 +8432,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0f), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8191,7 +8441,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0f), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8203,6 +8453,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToCfloat32() {
 
@@ -8220,7 +8471,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(120f), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8229,7 +8480,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0f), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8241,6 +8492,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToCfloat32() {
 
@@ -8258,7 +8510,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8267,7 +8519,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8276,7 +8528,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8288,6 +8540,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToCfloat32() {
 
@@ -8305,7 +8558,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(879542.125d), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8314,7 +8567,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float32(0d), cursor.next().getImaginaryFloat(), 0);
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat32").input(img).apply();
 		cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
@@ -8326,6 +8579,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToFloat64() {
 
@@ -8342,7 +8596,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(1), cursor.next().get(), 0);
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8353,6 +8607,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToFloat64() {
 
@@ -8369,7 +8624,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(2), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8380,6 +8635,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToFloat64() {
 
@@ -8396,7 +8652,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(15), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8407,6 +8663,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToFloat64() {
 
@@ -8423,7 +8680,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((byte) 8), cursor.next().get(), 0);
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8431,7 +8688,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((byte) 0), cursor.next().get(), 0);
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8442,6 +8699,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToFloat64() {
 
@@ -8458,7 +8716,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(100), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8469,6 +8727,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToFloat64() {
 
@@ -8485,7 +8744,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(212L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8496,6 +8755,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToFloat64() {
 
@@ -8512,7 +8772,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((short) 52), cursor.next().get(), 0);
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8520,7 +8780,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((short) 0), cursor.next().get(), 0);
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8531,6 +8791,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToFloat64() {
 
@@ -8547,7 +8808,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(480), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8558,6 +8819,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToFloat64() {
 
@@ -8574,7 +8836,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(301), cursor.next().get(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8582,7 +8844,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().get(), 0);
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8593,6 +8855,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToFloat64() {
 
@@ -8609,7 +8872,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(20L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8620,6 +8883,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToFloat64() {
 
@@ -8636,7 +8900,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(891L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8644,7 +8908,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().get(), 0);
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8655,6 +8919,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToFloat64() {
 
@@ -8671,7 +8936,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(1049L), cursor.next().get(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8679,7 +8944,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().get(), 0);
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8690,6 +8955,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToFloat64() {
 
@@ -8706,7 +8972,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(beef), cursor.next().get(), 0);
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8714,7 +8980,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(biZero), cursor.next().get(), 0);
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8725,6 +8991,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToFloat64() {
 
@@ -8741,7 +9008,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(123453.125f), cursor.next().get(), 0);
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8749,7 +9016,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0f), cursor.next().get(), 0);
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8760,6 +9027,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToFloat64() {
 
@@ -8776,7 +9044,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(5839.25f), cursor.next().get(), 0);
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8784,7 +9052,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0f), cursor.next().get(), 0);
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8795,6 +9063,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToFloat64() {
 
@@ -8811,7 +9080,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(4098d), cursor.next().get(), 0);
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8819,7 +9088,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().get(), 0);
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8827,7 +9096,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(-10948.015625d), cursor.next().get(), 0);
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8838,6 +9107,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToFloat64() {
 
@@ -8854,7 +9124,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(9087d), cursor.next().get(), 0);
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8862,7 +9132,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().get(), 0);
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.float64").input(img).apply();
 		cursor = ((IterableInterval<DoubleType>) converted).cursor();
@@ -8873,6 +9143,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testBitToCfloat64() {
 
@@ -8890,7 +9161,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(false);
+        b.set(false);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -8902,6 +9173,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint2ToCfloat64() {
 
@@ -8919,7 +9191,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -8931,6 +9203,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint4ToCfloat64() {
 
@@ -8948,7 +9221,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -8960,6 +9233,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt8ToCfloat64() {
 
@@ -8977,7 +9251,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((byte) 0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set((byte) 0);
+        b.set((byte) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -8986,7 +9260,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((byte) 0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set((byte) -12);
+        b.set((byte) -12);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -8998,6 +9272,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint8ToCfloat64() {
 
@@ -9015,7 +9290,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9027,6 +9302,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint12ToCfloat64() {
 
@@ -9044,7 +9320,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9056,6 +9332,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt16ToCfloat64() {
 
@@ -9073,7 +9350,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((short) 0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set((short) 0);
+        b.set((short) 0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9082,7 +9359,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64((short) 0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set((short) -154);
+        b.set((short) -154);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9094,6 +9371,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint16ToCfloat64() {
 
@@ -9111,7 +9389,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9123,6 +9401,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt32ToCfloat64() {
 
@@ -9140,7 +9419,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0);
+        b.set(0);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9149,7 +9428,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-89);
+        b.set(-89);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9161,6 +9440,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint32ToCfloat64() {
 
@@ -9178,7 +9458,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9190,6 +9470,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt64ToCfloat64() {
 
@@ -9207,7 +9488,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9216,7 +9497,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-1024L);
+        b.set(-1024L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9228,6 +9509,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint64ToCfloat64() {
 
@@ -9245,7 +9527,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0L);
+        b.set(0L);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9254,7 +9536,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0L), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(p64);
+        b.set(p64);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9266,6 +9548,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testUint128ToCfloat64() {
 
@@ -9283,7 +9566,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(biZero), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(biZero);
+        b.set(biZero);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9292,7 +9575,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(biZero), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(p128);
+        b.set(p128);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9304,6 +9587,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat32ToCfloat64() {
 
@@ -9321,7 +9605,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0f), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0f);
+        b.set(0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9330,7 +9614,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0f), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-2523485349058.0f);
+        b.set(-2523485349058.0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9342,6 +9626,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat32ToCfloat64() {
 
@@ -9359,7 +9644,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(120f), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0f, 0f);
+        b.set(0f, 0f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9368,7 +9653,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0f), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-4.25f, -123.0625f);
+        b.set(-4.25f, -123.0625f);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9380,6 +9665,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testFloat64ToCfloat64() {
 
@@ -9397,7 +9683,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0d);
+        b.set(0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9406,7 +9692,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-10948.015625d);
+        b.set(-10948.015625d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9415,7 +9701,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(1.0000152587890625e20);
+        b.set(1.0000152587890625e20);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9427,6 +9713,7 @@ public class TestConvertImages extends AbstractOpTest{
 	}
 
 	/** Tests {@link ConvertComplexTypes#integerToUint128}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testCfloat64ToCfloat64() {
 
@@ -9444,7 +9731,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(879542.125d), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(0d, 0d);
+        b.set(0d, 0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
@@ -9453,7 +9740,7 @@ public class TestConvertImages extends AbstractOpTest{
             assertEquals(Types.float64(0d), cursor.next().getImaginaryDouble(), 0);
 		}
 
-    b.set(-234.25d, -9.0d);
+        b.set(-234.25d, -9.0d);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.cfloat64").input(img).apply();
 		cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();

--- a/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/TestConvertImages.java
+++ b/scijava-ops-image/src/test/java/org/scijava/ops/image/convert/TestConvertImages.java
@@ -37,9 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
 
-import org.scijava.ops.image.AbstractOpTest;
 import net.imglib2.FinalDimensions;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -57,7 +56,10 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
 import org.junit.jupiter.api.Test;
+import org.scijava.ops.image.AbstractOpTest;
+import org.scijava.types.Nil;
 
 /**
  * Tests the {@link ConvertComplexTypes} ops.
@@ -84,7 +86,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(1), cursor.next().get());
@@ -111,7 +113,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(2), cursor.next().get());
@@ -138,7 +140,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(15), cursor.next().get());
@@ -165,7 +167,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit((byte) 8), cursor.next().get());
@@ -200,7 +202,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(100), cursor.next().get());
@@ -227,7 +229,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(212L), cursor.next().get());
@@ -254,7 +256,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit((short) 52), cursor.next().get());
@@ -289,7 +291,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(480), cursor.next().get());
@@ -316,7 +318,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(301), cursor.next().get());
@@ -351,7 +353,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(20L), cursor.next().get());
@@ -378,7 +380,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(891L), cursor.next().get());
@@ -413,7 +415,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(1049L), cursor.next().get());
@@ -448,7 +450,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(beef), cursor.next().get());
@@ -483,7 +485,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(123453.125f), cursor.next().get());
@@ -518,7 +520,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(5839.25f), cursor.next().get());
@@ -553,7 +555,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(4098d), cursor.next().get());
@@ -596,7 +598,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.bit").input(img).apply();
+        var converted = ops.op("convert.bit").input(img).apply();
 		var cursor = ((IterableInterval<BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.bit(9087d), cursor.next().get());
@@ -631,7 +633,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(1), cursor.next().get());
@@ -658,7 +660,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(2), cursor.next().get());
@@ -685,7 +687,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(15), cursor.next().get());
@@ -712,7 +714,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2((byte) 8), cursor.next().get());
@@ -747,7 +749,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(100), cursor.next().get());
@@ -774,7 +776,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(212L), cursor.next().get());
@@ -801,7 +803,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2((short) 52), cursor.next().get());
@@ -836,7 +838,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(480), cursor.next().get());
@@ -863,7 +865,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(301), cursor.next().get());
@@ -898,7 +900,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(20L), cursor.next().get());
@@ -925,7 +927,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(891L), cursor.next().get());
@@ -960,7 +962,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(1049L), cursor.next().get());
@@ -995,7 +997,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(beef), cursor.next().get());
@@ -1030,7 +1032,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(123453.125f), cursor.next().get());
@@ -1065,7 +1067,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(5839.25f), cursor.next().get());
@@ -1100,7 +1102,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(4098d), cursor.next().get());
@@ -1143,7 +1145,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint2").input(img).apply();
+        var converted = ops.op("convert.uint2").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned2BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint2(9087d), cursor.next().get());
@@ -1178,7 +1180,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(1), cursor.next().get());
@@ -1205,7 +1207,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(2), cursor.next().get());
@@ -1232,7 +1234,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(15), cursor.next().get());
@@ -1259,7 +1261,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4((byte) 8), cursor.next().get());
@@ -1294,7 +1296,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(100), cursor.next().get());
@@ -1321,7 +1323,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(212L), cursor.next().get());
@@ -1348,7 +1350,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4((short) 52), cursor.next().get());
@@ -1383,7 +1385,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(480), cursor.next().get());
@@ -1410,7 +1412,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(301), cursor.next().get());
@@ -1445,7 +1447,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(20L), cursor.next().get());
@@ -1472,7 +1474,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(891L), cursor.next().get());
@@ -1507,7 +1509,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(1049L), cursor.next().get());
@@ -1542,7 +1544,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(beef), cursor.next().get());
@@ -1577,7 +1579,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(123453.125f), cursor.next().get());
@@ -1612,7 +1614,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(5839.25f), cursor.next().get());
@@ -1647,7 +1649,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(4098d), cursor.next().get());
@@ -1690,7 +1692,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint4").input(img).apply();
+        var converted = ops.op("convert.uint4").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned4BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint4(9087d), cursor.next().get());
@@ -1725,7 +1727,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(1), cursor.next().get());
@@ -1752,7 +1754,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(2), cursor.next().get());
@@ -1779,7 +1781,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(15), cursor.next().get());
@@ -1806,7 +1808,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8((byte) 8), cursor.next().get());
@@ -1841,7 +1843,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(100), cursor.next().get());
@@ -1868,7 +1870,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(212L), cursor.next().get());
@@ -1895,7 +1897,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8((short) 52), cursor.next().get());
@@ -1930,7 +1932,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(480), cursor.next().get());
@@ -1957,7 +1959,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(301), cursor.next().get());
@@ -1992,7 +1994,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(20L), cursor.next().get());
@@ -2019,7 +2021,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(891L), cursor.next().get());
@@ -2054,7 +2056,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(1049L), cursor.next().get());
@@ -2089,7 +2091,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(beef), cursor.next().get());
@@ -2124,7 +2126,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(123453.125f), cursor.next().get());
@@ -2159,7 +2161,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(5839.25f), cursor.next().get());
@@ -2194,7 +2196,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(4098d), cursor.next().get());
@@ -2237,7 +2239,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int8").input(img).apply();
+        var converted = ops.op("convert.int8").input(img).apply();
 		var cursor = ((IterableInterval<ByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int8(9087d), cursor.next().get());
@@ -2272,7 +2274,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(1), cursor.next().get());
@@ -2299,7 +2301,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(2), cursor.next().get());
@@ -2326,7 +2328,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(15), cursor.next().get());
@@ -2353,7 +2355,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8((byte) 8), cursor.next().get());
@@ -2388,7 +2390,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(100), cursor.next().get());
@@ -2415,7 +2417,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(212L), cursor.next().get());
@@ -2442,7 +2444,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8((short) 52), cursor.next().get());
@@ -2477,7 +2479,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(480), cursor.next().get());
@@ -2504,7 +2506,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(301), cursor.next().get());
@@ -2539,7 +2541,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(20L), cursor.next().get());
@@ -2566,7 +2568,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(891L), cursor.next().get());
@@ -2601,7 +2603,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(1049L), cursor.next().get());
@@ -2636,7 +2638,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(beef), cursor.next().get());
@@ -2671,7 +2673,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(123453.125f), cursor.next().get());
@@ -2706,7 +2708,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(5839.25f), cursor.next().get());
@@ -2741,7 +2743,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(4098d), cursor.next().get());
@@ -2784,7 +2786,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint8").input(img).apply();
+        var converted = ops.op("convert.uint8").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedByteType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint8(9087d), cursor.next().get());
@@ -2819,7 +2821,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(1), cursor.next().get());
@@ -2846,7 +2848,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(2), cursor.next().get());
@@ -2873,7 +2875,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(15), cursor.next().get());
@@ -2900,7 +2902,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12((byte) 8), cursor.next().get());
@@ -2935,7 +2937,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(100), cursor.next().get());
@@ -2962,7 +2964,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(212L), cursor.next().get());
@@ -2989,7 +2991,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12((short) 52), cursor.next().get());
@@ -3024,7 +3026,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(480), cursor.next().get());
@@ -3051,7 +3053,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(301), cursor.next().get());
@@ -3086,7 +3088,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(20L), cursor.next().get());
@@ -3113,7 +3115,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(891L), cursor.next().get());
@@ -3148,7 +3150,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(1049L), cursor.next().get());
@@ -3183,7 +3185,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(beef), cursor.next().get());
@@ -3218,7 +3220,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(123453.125f), cursor.next().get());
@@ -3253,7 +3255,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(5839.25f), cursor.next().get());
@@ -3288,7 +3290,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(4098d), cursor.next().get());
@@ -3331,7 +3333,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint12").input(img).apply();
+        var converted = ops.op("convert.uint12").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned12BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint12(9087d), cursor.next().get());
@@ -3366,7 +3368,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(1), cursor.next().get());
@@ -3393,7 +3395,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(2), cursor.next().get());
@@ -3420,7 +3422,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(15), cursor.next().get());
@@ -3447,7 +3449,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16((byte) 8), cursor.next().get());
@@ -3482,7 +3484,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(100), cursor.next().get());
@@ -3509,7 +3511,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(212L), cursor.next().get());
@@ -3536,7 +3538,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16((short) 52), cursor.next().get());
@@ -3571,7 +3573,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(480), cursor.next().get());
@@ -3598,7 +3600,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(301), cursor.next().get());
@@ -3633,7 +3635,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(20L), cursor.next().get());
@@ -3660,7 +3662,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(891L), cursor.next().get());
@@ -3695,7 +3697,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(1049L), cursor.next().get());
@@ -3730,7 +3732,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(beef), cursor.next().get());
@@ -3765,7 +3767,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(123453.125f), cursor.next().get());
@@ -3800,7 +3802,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(5839.25f), cursor.next().get());
@@ -3835,7 +3837,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(4098d), cursor.next().get());
@@ -3878,7 +3880,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int16").input(img).apply();
+        var converted = ops.op("convert.int16").input(img).apply();
 		var cursor = ((IterableInterval<ShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int16(9087d), cursor.next().get());
@@ -3913,7 +3915,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(1), cursor.next().get());
@@ -3940,7 +3942,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(2), cursor.next().get());
@@ -3967,7 +3969,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(15), cursor.next().get());
@@ -3994,7 +3996,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16((byte) 8), cursor.next().get());
@@ -4029,7 +4031,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(100), cursor.next().get());
@@ -4056,7 +4058,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(212L), cursor.next().get());
@@ -4083,7 +4085,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16((short) 52), cursor.next().get());
@@ -4118,7 +4120,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(480), cursor.next().get());
@@ -4145,7 +4147,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(301), cursor.next().get());
@@ -4180,7 +4182,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(20L), cursor.next().get());
@@ -4207,7 +4209,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(891L), cursor.next().get());
@@ -4242,7 +4244,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(1049L), cursor.next().get());
@@ -4277,7 +4279,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(beef), cursor.next().get());
@@ -4312,7 +4314,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(123453.125f), cursor.next().get());
@@ -4347,7 +4349,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(5839.25f), cursor.next().get());
@@ -4382,7 +4384,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(4098d), cursor.next().get());
@@ -4425,7 +4427,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint16").input(img).apply();
+        var converted = ops.op("convert.uint16").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedShortType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint16(9087d), cursor.next().get());
@@ -4460,7 +4462,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(1), cursor.next().get());
@@ -4487,7 +4489,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(2), cursor.next().get());
@@ -4514,7 +4516,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(15), cursor.next().get());
@@ -4541,7 +4543,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32((byte) 8), cursor.next().get());
@@ -4576,7 +4578,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(100), cursor.next().get());
@@ -4603,7 +4605,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(212L), cursor.next().get());
@@ -4630,7 +4632,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32((short) 52), cursor.next().get());
@@ -4665,7 +4667,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(480), cursor.next().get());
@@ -4692,7 +4694,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(301), cursor.next().get());
@@ -4727,7 +4729,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(20L), cursor.next().get());
@@ -4754,7 +4756,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(891L), cursor.next().get());
@@ -4789,7 +4791,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(1049L), cursor.next().get());
@@ -4824,7 +4826,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(beef), cursor.next().get());
@@ -4859,7 +4861,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(123453.125f), cursor.next().get());
@@ -4894,7 +4896,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(5839.25f), cursor.next().get());
@@ -4929,7 +4931,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(4098d), cursor.next().get());
@@ -4972,7 +4974,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int32").input(img).apply();
+        var converted = ops.op("convert.int32").input(img).apply();
 		var cursor = ((IterableInterval<IntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int32(9087d), cursor.next().get());
@@ -5007,7 +5009,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(1), cursor.next().get());
@@ -5034,7 +5036,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(2), cursor.next().get());
@@ -5061,7 +5063,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(15), cursor.next().get());
@@ -5088,7 +5090,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32((byte) 8), cursor.next().get());
@@ -5123,7 +5125,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(100), cursor.next().get());
@@ -5150,7 +5152,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(212L), cursor.next().get());
@@ -5177,7 +5179,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32((short) 52), cursor.next().get());
@@ -5212,7 +5214,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(480), cursor.next().get());
@@ -5239,7 +5241,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(301), cursor.next().get());
@@ -5274,7 +5276,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(20L), cursor.next().get());
@@ -5301,7 +5303,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(891L), cursor.next().get());
@@ -5336,7 +5338,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(1049L), cursor.next().get());
@@ -5371,7 +5373,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(beef), cursor.next().get());
@@ -5406,7 +5408,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(123453.125f), cursor.next().get());
@@ -5441,7 +5443,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(5839.25f), cursor.next().get());
@@ -5476,7 +5478,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(4098d), cursor.next().get());
@@ -5519,7 +5521,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint32").input(img).apply();
+        var converted = ops.op("convert.uint32").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedIntType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint32(9087d), cursor.next().get());
@@ -5554,7 +5556,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(1), cursor.next().get());
@@ -5581,7 +5583,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(2), cursor.next().get());
@@ -5608,7 +5610,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(15), cursor.next().get());
@@ -5635,7 +5637,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64((byte) 8), cursor.next().get());
@@ -5670,7 +5672,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(100), cursor.next().get());
@@ -5697,7 +5699,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(212L), cursor.next().get());
@@ -5724,7 +5726,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64((short) 52), cursor.next().get());
@@ -5759,7 +5761,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(480), cursor.next().get());
@@ -5786,7 +5788,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(301), cursor.next().get());
@@ -5821,7 +5823,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(20L), cursor.next().get());
@@ -5848,7 +5850,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(891L), cursor.next().get());
@@ -5883,7 +5885,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(1049L), cursor.next().get());
@@ -5918,7 +5920,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(beef), cursor.next().get());
@@ -5953,7 +5955,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(123453.125f), cursor.next().get());
@@ -5988,7 +5990,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(5839.25f), cursor.next().get());
@@ -6023,7 +6025,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(4098d), cursor.next().get());
@@ -6066,7 +6068,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.int64").input(img).apply();
+        var converted = ops.op("convert.int64").input(img).apply();
 		var cursor = ((IterableInterval<LongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.int64(9087d), cursor.next().get());
@@ -6101,7 +6103,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(1), cursor.next().getBigInteger());
@@ -6128,7 +6130,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(2), cursor.next().getBigInteger());
@@ -6155,7 +6157,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(15), cursor.next().getBigInteger());
@@ -6182,7 +6184,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64((byte) 8), cursor.next().getBigInteger());
@@ -6217,7 +6219,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(100), cursor.next().getBigInteger());
@@ -6244,7 +6246,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(212L), cursor.next().getBigInteger());
@@ -6271,7 +6273,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64((short) 52), cursor.next().getBigInteger());
@@ -6306,7 +6308,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(480), cursor.next().getBigInteger());
@@ -6333,7 +6335,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(301), cursor.next().getBigInteger());
@@ -6368,7 +6370,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(20L), cursor.next().getBigInteger());
@@ -6395,7 +6397,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(891L), cursor.next().getBigInteger());
@@ -6430,7 +6432,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(1049L), cursor.next().getBigInteger());
@@ -6465,7 +6467,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(beef), cursor.next().getBigInteger());
@@ -6500,7 +6502,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(123453.125f), cursor.next().getBigInteger());
@@ -6535,7 +6537,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(5839.25f), cursor.next().getBigInteger());
@@ -6570,7 +6572,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(4098d), cursor.next().getBigInteger());
@@ -6613,7 +6615,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint64").input(img).apply();
+        var converted = ops.op("convert.uint64").input(img).apply();
 		var cursor = ((IterableInterval<UnsignedLongType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint64(9087d), cursor.next().getBigInteger());
@@ -6648,7 +6650,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(1), cursor.next().get());
@@ -6675,7 +6677,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(2), cursor.next().get());
@@ -6702,7 +6704,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(15), cursor.next().get());
@@ -6729,7 +6731,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128((byte) 8), cursor.next().get());
@@ -6764,7 +6766,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(100), cursor.next().get());
@@ -6791,7 +6793,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(212L), cursor.next().get());
@@ -6818,7 +6820,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128((short) 52), cursor.next().get());
@@ -6853,7 +6855,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(480), cursor.next().get());
@@ -6880,7 +6882,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(301), cursor.next().get());
@@ -6915,7 +6917,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(20L), cursor.next().get());
@@ -6942,7 +6944,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(891L), cursor.next().get());
@@ -6977,7 +6979,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(1049L), cursor.next().get());
@@ -7012,7 +7014,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(beef), cursor.next().get());
@@ -7047,7 +7049,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(123453.125f), cursor.next().get());
@@ -7082,7 +7084,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(5839.25f), cursor.next().get());
@@ -7117,7 +7119,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(4098d), cursor.next().get());
@@ -7160,7 +7162,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.uint128").input(img).apply();
+        var converted = ops.op("convert.uint128").input(img).apply();
 		var cursor = ((IterableInterval<Unsigned128BitType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.uint128(9087d), cursor.next().get());
@@ -7195,7 +7197,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(1), cursor.next().get(), 0);
@@ -7222,7 +7224,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(2), cursor.next().get(), 0);
@@ -7249,7 +7251,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(15), cursor.next().get(), 0);
@@ -7276,7 +7278,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32((byte) 8), cursor.next().get(), 0);
@@ -7311,7 +7313,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(100), cursor.next().get(), 0);
@@ -7338,7 +7340,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(212L), cursor.next().get(), 0);
@@ -7365,7 +7367,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32((short) 52), cursor.next().get(), 0);
@@ -7400,7 +7402,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(480), cursor.next().get(), 0);
@@ -7427,7 +7429,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(301), cursor.next().get(), 0);
@@ -7462,7 +7464,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(20L), cursor.next().get(), 0);
@@ -7489,7 +7491,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(891L), cursor.next().get(), 0);
@@ -7524,7 +7526,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(1049L), cursor.next().get(), 0);
@@ -7559,7 +7561,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(beef), cursor.next().get(), 0);
@@ -7594,7 +7596,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(123453.125f), cursor.next().get(), 0);
@@ -7629,7 +7631,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(5839.25f), cursor.next().get(), 0);
@@ -7664,7 +7666,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(4098d), cursor.next().get(), 0);
@@ -7707,7 +7709,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float32").input(img).apply();
+        var converted = ops.op("convert.float32").input(img).apply();
 		var cursor = ((IterableInterval<FloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(9087d), cursor.next().get(), 0);
@@ -7742,7 +7744,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(1), cursor.next().getRealFloat(), 0);
@@ -7771,7 +7773,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(2), cursor.next().getRealFloat(), 0);
@@ -7800,7 +7802,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(15), cursor.next().getRealFloat(), 0);
@@ -7829,7 +7831,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32((byte) 8), cursor.next().getRealFloat(), 0);
@@ -7867,7 +7869,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(100), cursor.next().getRealFloat(), 0);
@@ -7896,7 +7898,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(212L), cursor.next().getRealFloat(), 0);
@@ -7925,7 +7927,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32((short) 52), cursor.next().getRealFloat(), 0);
@@ -7963,7 +7965,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(480), cursor.next().getRealFloat(), 0);
@@ -7992,7 +7994,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(301), cursor.next().getRealFloat(), 0);
@@ -8030,7 +8032,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(20L), cursor.next().getRealFloat(), 0);
@@ -8059,7 +8061,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(891L), cursor.next().getRealFloat(), 0);
@@ -8097,7 +8099,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(1049L), cursor.next().getRealFloat(), 0);
@@ -8135,7 +8137,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(beef), cursor.next().getRealFloat(), 0);
@@ -8173,7 +8175,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(123453.125f), cursor.next().getRealFloat(), 0);
@@ -8211,7 +8213,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(5839.25f), cursor.next().getRealFloat(), 0);
@@ -8249,7 +8251,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(4098d), cursor.next().getRealFloat(), 0);
@@ -8296,7 +8298,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat32").input(img).apply();
+        var converted = ops.op("convert.cfloat32").input(img).apply();
 		var cursor = ((IterableInterval<ComplexFloatType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float32(9087d), cursor.next().getRealFloat(), 0);
@@ -8334,7 +8336,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(1), cursor.next().get(), 0);
@@ -8361,7 +8363,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(2), cursor.next().get(), 0);
@@ -8388,7 +8390,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(15), cursor.next().get(), 0);
@@ -8415,7 +8417,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64((byte) 8), cursor.next().get(), 0);
@@ -8450,7 +8452,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(100), cursor.next().get(), 0);
@@ -8477,7 +8479,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(212L), cursor.next().get(), 0);
@@ -8504,7 +8506,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64((short) 52), cursor.next().get(), 0);
@@ -8539,7 +8541,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(480), cursor.next().get(), 0);
@@ -8566,7 +8568,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(301), cursor.next().get(), 0);
@@ -8601,7 +8603,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(20L), cursor.next().get(), 0);
@@ -8628,7 +8630,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(891L), cursor.next().get(), 0);
@@ -8663,7 +8665,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(1049L), cursor.next().get(), 0);
@@ -8698,7 +8700,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(beef), cursor.next().get(), 0);
@@ -8733,7 +8735,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(123453.125f), cursor.next().get(), 0);
@@ -8768,7 +8770,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(5839.25f), cursor.next().get(), 0);
@@ -8803,7 +8805,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(4098d), cursor.next().get(), 0);
@@ -8846,7 +8848,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.float64").input(img).apply();
+        var converted = ops.op("convert.float64").input(img).apply();
 		var cursor = ((IterableInterval<DoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(9087d), cursor.next().get(), 0);
@@ -8881,7 +8883,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(1), cursor.next().getRealDouble(), 0);
@@ -8910,7 +8912,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(2), cursor.next().getRealDouble(), 0);
@@ -8939,7 +8941,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(15), cursor.next().getRealDouble(), 0);
@@ -8968,7 +8970,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64((byte) 8), cursor.next().getRealDouble(), 0);
@@ -9006,7 +9008,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(100), cursor.next().getRealDouble(), 0);
@@ -9035,7 +9037,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(212L), cursor.next().getRealDouble(), 0);
@@ -9064,7 +9066,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64((short) 52), cursor.next().getRealDouble(), 0);
@@ -9102,7 +9104,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(480), cursor.next().getRealDouble(), 0);
@@ -9131,7 +9133,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(301), cursor.next().getRealDouble(), 0);
@@ -9169,7 +9171,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(20L), cursor.next().getRealDouble(), 0);
@@ -9198,7 +9200,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(891L), cursor.next().getRealDouble(), 0);
@@ -9236,7 +9238,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(1049L), cursor.next().getRealDouble(), 0);
@@ -9274,7 +9276,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(beef), cursor.next().getRealDouble(), 0);
@@ -9312,7 +9314,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(123453.125f), cursor.next().getRealDouble(), 0);
@@ -9350,7 +9352,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(5839.25f), cursor.next().getRealDouble(), 0);
@@ -9388,7 +9390,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(4098d), cursor.next().getRealDouble(), 0);
@@ -9435,7 +9437,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.cfloat64").input(img).apply();
+        var converted = ops.op("convert.cfloat64").input(img).apply();
 		var cursor = ((IterableInterval<ComplexDoubleType>) converted).cursor();
 		while(cursor.hasNext()) {
             assertEquals(Types.float64(9087d), cursor.next().getRealDouble(), 0);

--- a/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/RAIConvertersTest.vm
+++ b/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/RAIConvertersTest.vm
@@ -20,20 +20,26 @@ import org.scijava.ops.image.AbstractOpTest;
 
 public class RAIConvertersTest extends AbstractOpTest {
 
+    private static final ArrayImg<DoubleType> DOUBLES = ArrayImgs.doubles(1, 1)
+
 #foreach ($toType in $types)
 	/**
+	 * @param in the input image
 	 * @param out the output image
 	 * @implNote op names='test.convert.image.${toType}', type='Computer'
 	 */
-	public static void compute$toType(RandomAccessibleInterval<$toType> out) {
+	public static void compute$toType(
+	    RandomAccessibleInterval<$toType> in,
+	    RandomAccessibleInterval<DoubleType> out
+	) {
 		LoopBuilder.setImages(out).forEachPixel(o -> o.setReal(1.0));
 	}
 
 	@Test
 	public void testConvert${toType}Image() {
-		var out = ArrayImgs.doubles(1, 1);
+		var in = ArrayImgs.doubles(1, 1);
 		out.firstElement().set(0.0);
-		ops.op("test.convert.image.${toType}").output(out).compute();
+		ops.op("test.convert.image.${toType}").input(in).output(DOUBLES).compute();
 		double expected = 1.0;
 		double actual = out.firstElement().get();
 		Assertions.assertEquals(expected, actual);

--- a/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/TestConvertImages.vm
+++ b/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/TestConvertImages.vm
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.math.BigInteger;
 
 import net.imglib2.FinalDimensions;
-import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.IterableInterval;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -28,10 +28,8 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.view.Views;
 import org.junit.jupiter.api.Test;
 import org.scijava.ops.image.AbstractOpTest;
-import org.scijava.types.Nil;
 
 /**
  * Tests the {@link ConvertComplexTypes} ops.
@@ -63,6 +61,7 @@ public class TestConvertImages extends AbstractOpTest{
 #set ($imgLibType2 = "$fromType.imglibT" + "Type")
 #set ($first = "true")
 	/** Tests {@link $className}. */
+	@SuppressWarnings("unchecked")
 	@Test
 	public void test${fromType.op}To${toType.op}() {
 
@@ -91,7 +90,7 @@ public class TestConvertImages extends AbstractOpTest{
 		}
 #set ($first = "false")
 #else
-    b.set($value.v);
+        b.set($value.v);
 		ops.op("image.fill").input(b).output(img).compute();
 		converted = ops.op("convert.$toType.built").input(img).apply();
 		cursor = ((IterableInterval<$imgLibType>) converted).cursor();

--- a/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/TestConvertImages.vm
+++ b/scijava-ops-image/templates/test/java/org/scijava/ops/image/convert/TestConvertImages.vm
@@ -9,9 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
 
-import org.scijava.ops.image.AbstractOpTest;
 import net.imglib2.FinalDimensions;
-import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.complex.ComplexDoubleType;
 import net.imglib2.type.numeric.complex.ComplexFloatType;
@@ -29,7 +28,10 @@ import net.imglib2.type.numeric.integer.UnsignedLongType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
 import org.junit.jupiter.api.Test;
+import org.scijava.ops.image.AbstractOpTest;
+import org.scijava.types.Nil;
 
 /**
  * Tests the {@link ConvertComplexTypes} ops.
@@ -73,7 +75,7 @@ public class TestConvertImages extends AbstractOpTest{
 				.apply();
 		ops.op("image.fill").input(b).output(img).compute();
 		// Create the converted image
-    var converted = ops.op("convert.$toType.built").input(img).apply();
+        var converted = ops.op("convert.$toType.built").input(img).apply();
 		var cursor = ((IterableInterval<$imgLibType>) converted).cursor();
 		while(cursor.hasNext()) {
 #if($toType.op.contains("C"))


### PR DESCRIPTION
This PR, based on a branch that was designed simply to streamline the conversion of `RandomAccessibleIntervals` via wrapping, has been taken over to add a new feature to Op conversion. Namely:

**Can we convert `Computer`s without that annoying copy at the end??**

## Background

Suppose you want to convert a `Computer<I, O>` into a `Computer<A, B>`. Currently, you need (at a minimum):
* An `engine.convert` Op that transforms your `A` object into an `I` object.
* An `engine.convert` Op that transforms your `B` object into an `O` object.
* An `engine.copy` Op that puts the data from an  `O` object into your `B` object **or** an `engine.convert` Op that transforms your `O` object into a `B` object *and* an `engine.copy` Op to put the data from the intermediary `B` object into the one you gave it.

In many cases, however, those `engine.convert` Ops will be most performant when *wrapping* the object. If that wrapper is read/write (as is the case for ndarray -> `RAI` wrapping via imglyb, for example), when the `Computer<I, O>` backing your `Computer<A, B>` Op is called, the changes will be *written through into the original `B` object*, and the later `engine.convert`/`engine.copy` is unnecessary work.

## A new Op name: `engine.wrap`

`engine.wrap` Ops are object conversions via a read/write wrapper. While not enforced, all `engine.wrap` Ops should be aliased `engine.convert` (and likely also `convert.X`).

When performing conversion, the Op conversion `MatchingRoutine` will watch for the usage of `engine.wrap` Ops. If used for a preallocated output, the matching routine will avoid matching the output `engine.convert`/`engine.copy` Ops.
 - In practice, this is a very simple change, as it is equivalent to the existing behavior that watches out for the `engine.identity` Op

## TODO:
* [ ] The proof of correctness here will be with inter-`ComplexType` image conversion, and as of right now the tests fail 😦. These tests must be fixed.
* [ ] Clean up PR (commits + code)
* [ ] Additional tests?
* [ ] Bump SciJava Ops Engine minor version, signifying new behavior.